### PR TITLE
[wpmlcore-5618] Check if variable is set before creating a String

### DIFF
--- a/src/modules/class-wpml-elementor-module-with-items.php
+++ b/src/modules/class-wpml-elementor-module-with-items.php
@@ -36,6 +36,11 @@ abstract class WPML_Elementor_Module_With_Items implements IWPML_Page_Builders_M
 		foreach ( $this->get_items( $element ) as $item ) {
 			foreach( $this->get_fields() as $key => $field ) {
 				if ( ! is_array( $field ) ) {
+
+					if ( ! isset( $item[ $field ] ) ) {
+						continue;
+					}
+
 					$strings[] = new WPML_PB_String(
 						$item[ $field ],
 						$this->get_string_name( $node_id, $item[ $field ], $field, $element['widgetType'], $item['_id'] ),

--- a/src/modules/class-wpml-elementor-module-with-items.php
+++ b/src/modules/class-wpml-elementor-module-with-items.php
@@ -44,6 +44,11 @@ abstract class WPML_Elementor_Module_With_Items implements IWPML_Page_Builders_M
 					);
 				} else {
 					foreach ( $field as $inner_field ) {
+
+						if ( ! isset( $item[ $key ][ $inner_field ] ) ) {
+							continue;
+						}
+
 						$strings[] = new WPML_PB_String(
 							$item[ $key ][ $inner_field ],
 							$this->get_string_name( $node_id, $item[ $key ][ $inner_field ], $inner_field, $item['_id'] ),


### PR DESCRIPTION
This fix is basically for CC. When you add Price List in a Elementor page, by default it always add "link" index in the JSON, even when it is empty. However, in the CC test it was not adding such index and throwing these notices.