### PR TITLE
Add support for custom styles in Elementor Pro templates

### DIFF
--- a/src/class-wpml-elementor-translate-ids.php
+++ b/src/class-wpml-elementor-translate-ids.php
@@ -50,8 +50,12 @@ class WPML_Elementor_Translate_IDs implements IWPML_Action {
 
 	public function translate_global_widget_ids( $data_array, $post_id ) {
 		foreach ( $data_array as &$data ) {
-			if ( isset( $data['elType'] ) && 'widget' === $data['elType'] && 'global' === $data['widgetType'] ) {
-				$data['templateID'] = $this->translate_id( $data['templateID'] );
+			if ( isset( $data['elType'] ) && 'widget' === $data['elType'] ) {
+				if ( 'global' === $data['widgetType'] ) {
+					$data['templateID'] = $this->translate_id( $data['templateID'] );
+				} elseif ( 'template' === $data['widgetType'] ) {
+					$data['settings']['template_id'] = $this->translate_id( $data['settings']['template_id'] );
+				}
 			}
 			$data['elements'] = $this->translate_global_widget_ids( $data['elements'], $post_id );
 		}

--- a/tests/phpunit/tests/test-wpml-elementor-translate-ids.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translate-ids.php
@@ -183,4 +183,94 @@ class Test_WPML_Elementor_Translate_IDs extends OTGS_TestCase {
 		$this->assertEquals( $template_id, $subject->translate_template_id( $template_id ) );
 	}
 
+	/**
+	 * @test
+	 * @dataProvider dp_global_widget
+	 * @group wpmlpb-153
+	 *
+	 * @param array $data
+	 * @param array $expected_data
+	 * @param int   $original_template_id
+	 * @param int   $translated_template_id
+	 */
+	public function it_should_translate_global_widget_ids( $data, $expected_data, $original_template_id, $translated_template_id ) {
+		$post_type = 'anything';
+
+		\WP_Mock::userFunction( 'get_post_type', array(
+			'args'   => $original_template_id,
+			'return' => $post_type,
+		));
+
+		\WP_Mock::onFilter( 'wpml_object_id' )
+		        ->with( (string) $original_template_id, $post_type, true )
+		        ->reply( $translated_template_id );
+
+		$debug_backtrace = \Mockery::mock( 'WPML_Debug_BackTrace' );
+
+		$subject = new WPML_Elementor_Translate_IDs( $debug_backtrace );
+
+		$this->assertEquals(
+			$expected_data,
+			$subject->translate_global_widget_ids( $data, mt_rand( 1001, 2000 ) )
+		);
+	}
+
+	public function dp_global_widget() {
+		$original_template_id   = mt_rand( 1, 100 );
+		$translated_template_id = mt_rand( 101, 200 );
+
+		$data = array(
+			array(
+				'id' => '9246df0',
+				'elType' => 'section',
+				'settings' => array(),
+				'elements' => array(
+					array(
+						'id' => '9262c46',
+						'elType' => 'column',
+						'settings' => array(
+							'_column_size' => 100,
+						),
+						'elements' => array(
+							array(
+								'id' => 'ea1182b',
+								'elType' => 'widget',
+								'elements' => array(),
+							),
+						),
+						'isInner' => false,
+					),
+				),
+				'isInner' => false,
+			),
+		);
+
+		$data_global = $data;
+		$data_global[0]['elements'][0]['elements'][0]['widgetType'] = 'global';
+		$data_global[0]['elements'][0]['elements'][0]['templateID'] = (string) $original_template_id;
+		$expected_data_global = $data_global;
+		$expected_data_global[0]['elements'][0]['elements'][0]['templateID'] = $translated_template_id;
+
+		$data_template = $data;
+		$data_template[0]['elements'][0]['elements'][0]['widgetType'] = 'template';
+		$data_template[0]['elements'][0]['elements'][0]['settings']['template_id'] = (string) $original_template_id;
+		$expected_data_template = $data_template;
+		$expected_data_template[0]['elements'][0]['elements'][0]['settings']['template_id'] = $translated_template_id;
+
+		return array(
+			'global widget templateID' => array(
+				$data_global,
+				$expected_data_global,
+				$original_template_id,
+				$translated_template_id,
+
+			),
+			'template widget template_id' => array(
+				$data_template,
+				$expected_data_template,
+				$original_template_id,
+				$translated_template_id,
+			),
+		);
+	}
 }


### PR DESCRIPTION
Also covered method
`WPML_Elementor_Translate_IDs::translate_global_widget_ids` with tests
for both "global" and "template" elements.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-153