### PR TITLE
Reduce cross-dependency between page builder packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
   },
   "require": {
     "roave/security-advisories": "dev-master",
-    "wpml/page-builders": "dev-master",
     "jakeasmith/http_build_url": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",
-    "otgs/unit-tests-framework": "~1.2.0"
+    "otgs/unit-tests-framework": "~1.2.0",
+    "wpml/page-builders": "dev-master"
   }
 }


### PR DESCRIPTION
Moved `wpml/page-builders` to the dev dependencies.

Note that this does not have any incidence on the `composer.lock` file.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-155