### PR TITLE
Translate images in non-translatable blocks for Elementor

### DIFF
--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -5,6 +5,8 @@
  */
 class WPML_Elementor_Integration_Factory {
 
+	const SLUG = 'elementor';
+
 	/**
 	 * @return WPML_Page_Builders_Integration
 	 */
@@ -17,6 +19,7 @@ class WPML_Elementor_Integration_Factory {
 				'WPML_Elementor_Media_Translation_Factory',
 				'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
 				'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
+				'WPML_Elementor_Media_Hooks_Factory',
 			)
 		);
 

--- a/src/media/class-wpml-elementor-media-hooks-factory.php
+++ b/src/media/class-wpml-elementor-media-hooks-factory.php
@@ -1,0 +1,11 @@
+<?php
+
+class WPML_Elementor_Media_Hooks_Factory implements IWPML_Backend_Action_Loader {
+
+	public function create() {
+		return new WPML_Page_Builders_Media_Hooks(
+			new WPML_Elementor_Update_Media_Factory(),
+			WPML_Elementor_Integration_Factory::SLUG
+		);
+	}
+}

--- a/src/media/class-wpml-elementor-media-node-provider.php
+++ b/src/media/class-wpml-elementor-media-node-provider.php
@@ -1,0 +1,78 @@
+<?php
+
+class WPML_Elementor_Media_Node_Provider {
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	private $media_translate;
+
+	/** @var WPML_Elementor_Media_Node[] */
+	private $nodes = array();
+
+	/**
+	 * @param string $type
+	 *
+	 * @return WPML_Elementor_Media_Node
+	 */
+	public function get( $type ) {
+		if ( ! array_key_exists( $type, $this->nodes ) ) {
+			switch ( $type ) {
+				case 'image':
+					$node = new WPML_Elementor_Media_Node_Image( $this->get_media_translate() );
+					break;
+
+				case 'slides':
+					$node = new WPML_Elementor_Media_Node_Slides( $this->get_media_translate() );
+					break;
+
+				case 'call-to-action':
+					$node = new WPML_Elementor_Media_Node_Call_To_Action( $this->get_media_translate() );
+					break;
+
+				case 'media-carousel':
+					$node = new WPML_Elementor_Media_Node_Media_Carousel( $this->get_media_translate() );
+					break;
+
+				case 'image-box':
+					$node = new WPML_Elementor_Media_Node_Image_Box( $this->get_media_translate() );
+					break;
+
+				case 'image-gallery':
+					$node = new WPML_Elementor_Media_Node_Image_Gallery( $this->get_media_translate() );
+					break;
+
+				case 'image-carousel':
+					$node = new WPML_Elementor_Media_Node_Image_Carousel( $this->get_media_translate() );
+					break;
+
+				case 'wp-widget-media_image':
+					$node = new WPML_Elementor_Media_Node_WP_Widget_Media_Image( $this->get_media_translate() );
+					break;
+
+				case 'wp-widget-media_gallery':
+					$node = new WPML_Elementor_Media_Node_WP_Widget_Media_Gallery( $this->get_media_translate() );
+					break;
+
+				default:
+					$node = null;
+			}
+
+			$this->nodes[ $type ] = $node;
+		}
+
+		return $this->nodes[ $type ];
+	}
+
+	/** @return WPML_Page_Builders_Media_Translate */
+	private function get_media_translate() {
+		global $sitepress;
+
+		if ( ! $this->media_translate ) {
+			$this->media_translate = new WPML_Page_Builders_Media_Translate(
+				new WPML_Translation_Element_Factory( $sitepress ),
+				new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
+			);
+		}
+
+		return $this->media_translate;
+	}
+}

--- a/src/media/class-wpml-elementor-media-nodes-iterator.php
+++ b/src/media/class-wpml-elementor-media-nodes-iterator.php
@@ -1,0 +1,66 @@
+<?php
+
+class WPML_Elementor_Media_Nodes_Iterator implements IWPML_PB_Media_Nodes_Iterator {
+
+	/** @var WPML_Elementor_Media_Node_Provider $node_provider */
+	private $node_provider;
+
+	public function __construct( WPML_Elementor_Media_Node_Provider $node_provider ) {
+		$this->node_provider = $node_provider;
+	}
+
+	/**
+	 * @param array $data_array
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return array
+	 */
+	public function translate( $data_array, $lang, $source_lang ) {
+		foreach ( $data_array as &$node ) {
+			if ( $this->is_parent_node( $node ) ) {
+				$node['elements'] = $this->translate( $node['elements'], $lang, $source_lang );
+			} elseif ( $this->is_valid_media_node( $node ) ) {
+				$node = $this->translate_node( $node, $lang, $source_lang );
+			}
+		}
+
+		return $data_array;
+	}
+
+	/**
+	 * @param array $node
+	 *
+	 * @return bool
+	 */
+	private function is_parent_node( $node ) {
+		return isset( $node['elements'] ) && $node['elements'];
+	}
+
+	/**
+	 * @param array $node
+	 *
+	 * @return bool
+	 */
+	private function is_valid_media_node( $node ) {
+		return isset( $node['elType'], $node['widgetType'], $node['settings'] )
+		       && 'widget' === $node['elType'];
+	}
+
+	/**
+	 * @param stdClass $node_data
+	 * @param string   $lang
+	 * @param string   $source_lang
+	 *
+	 * @return stdClass
+	 */
+	private function translate_node( $node_data, $lang, $source_lang ) {
+		$node = $this->node_provider->get( $node_data['widgetType'] );
+
+		if ( $node ) {
+			$node_data['settings'] = $node->translate( $node_data['settings'], $lang, $source_lang );
+		}
+
+		return $node_data;
+	}
+}

--- a/src/media/class-wpml-elementor-update-media-factory.php
+++ b/src/media/class-wpml-elementor-update-media-factory.php
@@ -1,0 +1,14 @@
+<?php
+
+class WPML_Elementor_Update_Media_Factory implements IWPML_PB_Media_Update_Factory {
+
+	public function create() {
+		global $sitepress;
+
+		return new WPML_Page_Builders_Update_Media(
+			new WPML_Page_Builders_Update( new WPML_Elementor_Data_Settings() ),
+			new WPML_Translation_Element_Factory( $sitepress ),
+			new WPML_Elementor_Media_Nodes_Iterator( new WPML_Elementor_Media_Node_Provider() )
+		);
+	}
+}

--- a/src/media/modules/abstract/class-wpml-elementor-media-node-with-image-property.php
+++ b/src/media/modules/abstract/class-wpml-elementor-media-node-with-image-property.php
@@ -1,0 +1,18 @@
+<?php
+
+abstract class WPML_Elementor_Media_Node_With_Image_Property extends WPML_Elementor_Media_Node {
+
+	/** @return string */
+	abstract protected function get_property_name();
+
+	/**
+	 * @param array  $settings
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	public function translate( $settings, $target_lang, $source_lang ) {
+		return $this->translate_image_property( $settings, $this->get_property_name(), $target_lang, $source_lang );
+	}
+}

--- a/src/media/modules/abstract/class-wpml-elementor-media-node-with-images-property.php
+++ b/src/media/modules/abstract/class-wpml-elementor-media-node-with-images-property.php
@@ -1,0 +1,18 @@
+<?php
+
+abstract class WPML_Elementor_Media_Node_With_Images_Property extends WPML_Elementor_Media_Node {
+
+	/** @return string */
+	abstract protected function get_property_name();
+
+	/**
+	 * @param array  $settings
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	public function translate( $settings, $target_lang, $source_lang ) {
+		return $this->translate_images_property( $settings, $this->get_property_name(), $target_lang, $source_lang );
+	}
+}

--- a/src/media/modules/abstract/class-wpml-elementor-media-node-with-slides.php
+++ b/src/media/modules/abstract/class-wpml-elementor-media-node-with-slides.php
@@ -1,0 +1,26 @@
+<?php
+
+abstract class WPML_Elementor_Media_Node_With_Slides extends WPML_Elementor_Media_Node {
+
+	/** @return string */
+	abstract protected function get_image_property_name();
+
+	/**
+	 * @param array  $settings
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	public function translate( $settings, $target_lang, $source_lang ) {
+		if ( ! isset( $settings['slides'] ) || ! is_array( $settings['slides'] ) ) {
+			return $settings;
+		}
+
+		foreach ( $settings['slides'] as &$slide ) {
+			$slide = $this->translate_image_property( $slide, $this->get_image_property_name(), $target_lang, $source_lang );
+		}
+
+		return $settings;
+	}
+}

--- a/src/media/modules/abstract/class-wpml-elementor-media-node.php
+++ b/src/media/modules/abstract/class-wpml-elementor-media-node.php
@@ -1,0 +1,66 @@
+<?php
+
+abstract class WPML_Elementor_Media_Node {
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	protected $media_translate;
+
+	public function __construct( WPML_Page_Builders_Media_Translate $media_translate ) {
+		$this->media_translate = $media_translate;
+	}
+
+	/**
+	 * @param array  $settings
+	 * @param string $property
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	protected function translate_image_property( $settings, $property, $lang, $source_lang ) {
+		if ( isset( $settings[ $property ] ) ) {
+			$settings[ $property ] = $this->translate_image_array( $settings[ $property ], $lang, $source_lang );
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * @param array  $settings
+	 * @param string $property
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	protected function translate_images_property( $settings, $property, $lang, $source_lang ) {
+		if ( isset( $settings[ $property ] ) ) {
+
+			foreach ( $settings[ $property ] as &$image ) {
+				$image = $this->translate_image_array( $image, $lang, $source_lang );
+			}
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * @param array $image
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	private function translate_image_array( $image, $lang, $source_lang ) {
+		if ( isset( $image['id'] ) && $image['id'] ) {
+			$image['id'] = $this->media_translate->translate_id( $image['id'], $lang );
+		}
+		if ( isset( $image['url'] ) && $image['url'] ) {
+			$image['url'] = $this->media_translate->translate_image_url( $image['url'], $lang, $source_lang );
+		}
+
+		return $image;
+	}
+
+	abstract function translate( $settings, $target_lang, $source_lang );
+}

--- a/src/media/modules/class-wpml-elementor-media-node-call-to-action.php
+++ b/src/media/modules/class-wpml-elementor-media-node-call-to-action.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Elementor_Media_Node_Call_To_Action extends WPML_Elementor_Media_Node_With_Image_Property {
+
+	protected function get_property_name() {
+		return 'bg_image';
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-image-box.php
+++ b/src/media/modules/class-wpml-elementor-media-node-image-box.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Elementor_Media_Node_Image_Box extends WPML_Elementor_Media_Node_With_Image_Property {
+
+	protected function get_property_name() {
+		return 'image';
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-image-carousel.php
+++ b/src/media/modules/class-wpml-elementor-media-node-image-carousel.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Elementor_Media_Node_Image_Carousel extends WPML_Elementor_Media_Node_With_Images_Property {
+
+	protected function get_property_name() {
+		return 'carousel';
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-image-gallery.php
+++ b/src/media/modules/class-wpml-elementor-media-node-image-gallery.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Elementor_Media_Node_Image_Gallery extends WPML_Elementor_Media_Node_With_Images_Property {
+
+	protected function get_property_name() {
+		return 'wp_gallery';
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-image.php
+++ b/src/media/modules/class-wpml-elementor-media-node-image.php
@@ -1,0 +1,24 @@
+<?php
+
+class WPML_Elementor_Media_Node_Image extends WPML_Elementor_Media_Node {
+
+	/**
+	 * @param array  $settings
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return array
+	 */
+	public function translate( $settings, $target_lang, $source_lang ) {
+		$settings = $this->translate_image_property( $settings, 'image', $target_lang, $source_lang );
+		$settings = $this->translate_image_property( $settings, '_background_image', $target_lang, $source_lang );
+		$settings = $this->translate_image_property( $settings, '_background_hover_image', $target_lang, $source_lang );
+
+		if ( isset( $settings['caption'], $settings['image']['id'] ) ) {
+			$image_data          = wp_prepare_attachment_for_js( $settings['image']['id'] );
+			$settings['caption'] = $image_data['caption'];
+		}
+
+		return $settings;
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-media-carousel.php
+++ b/src/media/modules/class-wpml-elementor-media-node-media-carousel.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Elementor_Media_Node_Media_Carousel extends WPML_Elementor_Media_Node_With_Slides {
+
+	protected function get_image_property_name() {
+		return 'image';
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-slides.php
+++ b/src/media/modules/class-wpml-elementor-media-node-slides.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Elementor_Media_Node_Slides extends WPML_Elementor_Media_Node_With_Slides {
+
+	protected function get_image_property_name() {
+		return 'background_image';
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-wp-widget-media-gallery.php
+++ b/src/media/modules/class-wpml-elementor-media-node-wp-widget-media-gallery.php
@@ -1,0 +1,25 @@
+<?php
+
+class WPML_Elementor_Media_Node_WP_Widget_Media_Gallery extends WPML_Elementor_Media_Node {
+
+	/**
+	 * @param array  $settings
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return array
+	 */
+	public function translate( $settings, $target_lang, $source_lang ) {
+		if ( isset( $settings['wp']['ids'] ) ) {
+			$ids = explode( ',', $settings['wp']['ids'] );
+
+			foreach ( $ids as &$id ) {
+				$id = $this->media_translate->translate_id( (int) $id, $target_lang );
+			}
+
+			$settings['wp']['ids'] = implode( ',', $ids );
+		}
+
+		return $settings;
+	}
+}

--- a/src/media/modules/class-wpml-elementor-media-node-wp-widget-media-image.php
+++ b/src/media/modules/class-wpml-elementor-media-node-wp-widget-media-image.php
@@ -1,0 +1,34 @@
+<?php
+
+class WPML_Elementor_Media_Node_WP_Widget_Media_Image extends WPML_Elementor_Media_Node {
+
+	/**
+	 * @param array  $settings
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return mixed
+	 */
+	public function translate( $settings, $target_lang, $source_lang ) {
+		if ( isset( $settings['wp']['attachment_id'] ) ) {
+			$translated_id = $this->media_translate->translate_id( $settings['wp']['attachment_id'], $target_lang );
+
+			if ( $translated_id !== (int) $settings['wp']['attachment_id'] ) {
+				$settings['wp']['attachment_id'] = $translated_id;
+
+				$settings['wp']['url'] = $this->media_translate->translate_image_url(
+					$settings['wp']['url'],
+					$target_lang,
+					$source_lang
+				);
+
+				$image_data                    = wp_prepare_attachment_for_js( $translated_id );
+				$settings['wp']['caption']     = $image_data['caption'];
+				$settings['wp']['alt']         = $image_data['alt'];
+				$settings['wp']['image_title'] = $image_data['title'];
+			}
+		}
+
+		return $settings;
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-call-to-action.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-call-to-action.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Call_To_Action extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'bg_image' => array( 'id' => $original_id, 'url' => $original_url ),
+		);
+
+		$expected_settings = array(
+			'bg_image' => array( 'id' => $translated_id, 'url' => $translated_url ),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_property_is_missing() {
+		$settings = array( 'something' );
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Call_To_Action( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+			->setMethods( array( 'translate_id', 'translate_image_url' ) )
+			->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image-box.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image-box.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Image_Box extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'image' => array( 'id' => $original_id, 'url' => $original_url ),
+		);
+
+		$expected_settings = array(
+			'image' => array( 'id' => $translated_id, 'url' => $translated_url ),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_property_is_missing() {
+		$settings = array( 'something' );
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Image_Box( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image-carousel.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image-carousel.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Image_Carousel extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'carousel' => array(
+				array( 'id' => $original_id, 'url' => $original_url ),
+			),
+		);
+
+		$expected_settings = array(
+			'carousel' => array(
+				array( 'id' => $translated_id, 'url' => $translated_url ),
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_property_is_missing() {
+		$settings = array( 'something' );
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Image_Carousel( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image-gallery.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image-gallery.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Image_Gallery extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'wp_gallery' => array(
+				array( 'id' => $original_id, 'url' => $original_url ),
+			),
+		);
+
+		$expected_settings = array(
+			'wp_gallery' => array(
+				array( 'id' => $translated_id, 'url' => $translated_url ),
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_property_is_missing() {
+		$settings = array( 'something' );
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Image_Gallery( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Image extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'image'                   => array( 'id' => $original_id, 'url' => $original_url ),
+			'_background_image'       => array( 'id' => $original_id, 'url' => $original_url ),
+			'_background_hover_image' => array( 'id' => $original_id, 'url' => $original_url ),
+			'caption'                 => 'The caption',
+		);
+
+		$expected_settings = array(
+			'image'                   => array( 'id' => $translated_id, 'url' => $translated_url ),
+			'_background_image'       => array( 'id' => $translated_id, 'url' => $translated_url ),
+			'_background_hover_image' => array( 'id' => $translated_id, 'url' => $translated_url ),
+			'caption'                 => $target_lang . 'The caption',
+		);
+
+		\WP_Mock::userFunction( 'wp_prepare_attachment_for_js', array(
+			'args' => array( $translated_id ),
+			'return' => array(
+				'caption' => $target_lang . 'The caption',
+			),
+		));
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_translate_if_properties_missing_or_empty() {
+		$settings = array(
+			'image'   => array( 'id' => '' ),
+			'caption' => '',
+		);
+
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Image( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-media-carousel.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-media-carousel.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Media_Carousel extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'slides' => array(
+				array(
+					'image' => array( 'id' => $original_id, 'url' => $original_url ),
+				),
+			),
+		);
+
+		$expected_settings = array(
+			'slides' => array(
+				array(
+					'image' => array( 'id' => $translated_id, 'url' => $translated_url ),
+				),
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_should_not_translate
+	 *
+	 * @param array $settings
+	 */
+	public function it_should_not_translate_if_slide_is_incomplete( $settings ) {
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	public function dp_should_not_translate() {
+		return array(
+			array( array() ),
+			array( array( 'slides' => 'no an array' ) ),
+			array( array( 'slides' => array( 'image' => array() ) ) ),
+		);
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Media_Carousel( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-slides.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-slides.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Slides extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 23;
+		$translated_id  = 45;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'slides' => array(
+				array(
+					'background_image' => array( 'id' => $original_id, 'url' => $original_url ),
+				),
+			),
+		);
+
+		$expected_settings = array(
+			'slides' => array(
+				array(
+					'background_image' => array( 'id' => $translated_id, 'url' => $translated_url ),
+				),
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_should_not_translate
+	 *
+	 * @param array $settings
+	 */
+	public function it_should_not_translate_if_slide_is_incomplete( $settings ) {
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	public function dp_should_not_translate() {
+		return array(
+			array( array() ),
+			array( array( 'slides' => 'no an array' ) ),
+			array( array( 'slides' => array( 'background_image' => array() ) ) ),
+		);
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_Slides( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-wp-widget-media-gallery.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-wp-widget-media-gallery.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_WP_Widget_Media_Gallery extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang     = 'en';
+		$target_lang     = 'fr';
+		$original_id_1   = 25;
+		$original_id_2   = 26;
+		$translated_id_1 = 49;
+		$translated_id_2 = 43;
+
+		$settings = array(
+			'wp' => array(
+				'ids' => "$original_id_1,$original_id_2",
+			),
+		);
+
+		$expected_settings = array(
+			'wp' => array(
+				'ids' => "$translated_id_1,$translated_id_2",
+			),
+		);
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->willReturnMap(
+			array(
+				array( $original_id_1, $target_lang, $translated_id_1 ),
+				array( $original_id_2, $target_lang, $translated_id_2 ),
+			)
+		);
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_should_not_translate
+	 *
+	 * @param array $settings
+	 */
+	public function it_should_not_translate_if_slide_is_incomplete( $settings ) {
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	public function dp_should_not_translate() {
+		return array(
+			array( array() ),
+			array( array( 'wp' => 'no an array' ) ),
+			array( array( 'wp' => array( 'ids' => '' ) ) ),
+		);
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_WP_Widget_Media_Gallery( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-wp-widget-media-image.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-wp-widget-media-image.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_WP_Widget_Media_Image extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_id    = 25;
+		$translated_id  = 49;
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'wp' => array(
+				'attachment_id' => $original_id,
+				'url'           => $original_url,
+				'caption'       => 'the caption',
+				'alt'           => 'the alt',
+				'image_title'   => 'the image title',
+			),
+		);
+
+		$expected_settings = array(
+			'wp' => array(
+				'attachment_id' => $translated_id,
+				'url'           => $translated_url,
+				'caption'       => $target_lang . 'the caption',
+				'alt'           => $target_lang . 'the alt',
+				'image_title'   => $target_lang . 'the image title',
+			),
+		);
+
+		\WP_Mock::userFunction( 'wp_prepare_attachment_for_js', array(
+			'args' => array( $translated_id ),
+			'return' => array(
+				'caption' => $target_lang . 'the caption',
+				'alt'     => $target_lang . 'the alt',
+				'title'   => $target_lang . 'the image title',
+			),
+		));
+
+		$media_translate = $this->get_media_translate();
+		$media_translate->method( 'translate_id' )->with( $original_id, $target_lang )->willReturn( $translated_id );
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )->willReturn( $translated_url );
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_should_not_translate
+	 *
+	 * @param array $settings
+	 */
+	public function it_should_not_translate_if_slide_is_incomplete( $settings ) {
+		$media_translate = $this->get_media_translate();
+
+		$subject = $this->get_subject( $media_translate );
+
+		$this->assertEquals( $settings, $subject->translate( $settings, 'fr', 'en' ) );
+	}
+
+	public function dp_should_not_translate() {
+		return array(
+			array( array() ),
+			array( array( 'wp' => 'no an array' ) ),
+		);
+	}
+
+	private function get_subject( $media_translate ) {
+		return new WPML_Elementor_Media_Node_WP_Widget_Media_Image( $media_translate );
+	}
+
+	private function get_media_translate() {
+		return $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		            ->setMethods( array( 'translate_id', 'translate_image_url' ) )
+		            ->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/test-wpml-elementor-media-hooks-factory.php
+++ b/tests/phpunit/tests/media/test-wpml-elementor-media-hooks-factory.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Hooks_Factory extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_and_return_an_instance() {
+		$GLOBALS['sitepress'] = $this->getMockBuilder( 'SitePress' )->getMock();
+		\Mockery::mock( 'alias:WPML_Page_Builders_Media_Hooks' );
+		$subject = new WPML_Elementor_Media_Hooks_Factory();
+		$this->assertInstanceOf( 'WPML_Page_Builders_Media_Hooks', $subject->create() );
+	}
+}
+
+if ( ! interface_exists( 'IWPML_PB_Media_Update_Factory' ) ) {
+	interface IWPML_PB_Media_Update_Factory {}
+}

--- a/tests/phpunit/tests/media/test-wpml-elementor-media-node-provider.php
+++ b/tests/phpunit/tests/media/test-wpml-elementor-media-node-provider.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Node_Provider extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dp_node_types
+	 *
+	 * @param string $type
+	 * @param string $class_name
+	 */
+	public function it_should_return_a_node_instance_and_cache_it( $type, $class_name ) {
+		$GLOBALS['sitepress'] = $this->getMockBuilder( 'SitePress' )->disableOriginalConstructor()->getMock();
+		$this->mock_external_classes();
+
+		$subject = new WPML_Elementor_Media_Node_Provider();
+
+		$this->assertInstanceOf( $class_name, $subject->get( $type ) );
+		$this->assertSame( $subject->get( $type ), $subject->get( $type ) );
+	}
+
+	public function dp_node_types() {
+		return array(
+			'image'                   => array( 'image', 'WPML_Elementor_Media_Node_Image' ),
+			'slides'                  => array( 'slides', 'WPML_Elementor_Media_Node_Slides' ),
+			'call-to-action'          => array( 'call-to-action', 'WPML_Elementor_Media_Node_Call_To_Action' ),
+			'media-carousel'          => array( 'media-carousel', 'WPML_Elementor_Media_Node_Media_Carousel' ),
+			'image-box'               => array( 'image-box', 'WPML_Elementor_Media_Node_Image_Box' ),
+			'image-gallery'           => array( 'image-gallery', 'WPML_Elementor_Media_Node_Image_Gallery' ),
+			'image-carousel'          => array( 'image-carousel', 'WPML_Elementor_Media_Node_Image_Carousel' ),
+			'wp-widget-media_image'   => array( 'wp-widget-media_image', 'WPML_Elementor_Media_Node_WP_Widget_Media_Image' ),
+			'wp-widget-media_gallery' => array( 'wp-widget-media_gallery', 'WPML_Elementor_Media_Node_WP_Widget_Media_Gallery' ),
+		);
+	}
+
+	private function mock_external_classes() {
+		$this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )->getMock();
+		$this->getMockBuilder( 'WPML_Translation_Element_Factory' )->getMock();
+		$this->getMockBuilder( 'WPML_Media_Image_Translate' )->getMock();
+		$this->getMockBuilder( 'WPML_Media_Attachment_By_URL_Factory' )->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/test-wpml-elementor-media-nodes-iterator.php
+++ b/tests/phpunit/tests/media/test-wpml-elementor-media-nodes-iterator.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Media_Nodes_Iterator extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$lang        = 'fr';
+		$source_lang = 'en';
+
+		$image_data  = array( 'original image data' );
+		$slides_data = array( 'original slides data' );
+
+		$data = array(
+			array(
+				'elType'   => 'column',
+				'elements' => array(
+					array(
+						'elType'     => 'widget',
+						'widgetType' => 'image',
+						'settings'   => $image_data,
+					),
+				),
+			),
+			array(
+				'elType'     => 'widget',
+				'widgetType' => 'slides',
+				'settings'   => $slides_data,
+				'elements'   => array(),
+			),
+			// Not supported module
+			 array(
+				'elType'     => 'widget',
+				'widgetType' => 'not-supported',
+				'settings'   => array(),
+				'elements'   => array(),
+			),
+			// Not translated modules
+			array(),
+			array( 'elType' => 'not a widget' ),
+			array( 'elType' => 'widget' ),
+			array( 'elType' => 'widget', 'settings' => array() ),
+			array( 'elType' => 'widget', 'widgetType' => 'image' ),
+		);
+
+		$translated_image_data  = array( 'translated image data' );
+		$translated_slides_data = array( 'translated slides data' );
+
+		$expected_data                               = $data;
+		$expected_data[0]['elements'][0]['settings'] = $translated_image_data;
+		$expected_data[1]['settings']                = $translated_slides_data;
+
+
+		$node_image = $this->get_node();
+		$node_image->method( 'translate' )->with( $image_data, $lang, $source_lang )
+			->willReturn( $translated_image_data );
+
+		$node_slides = $this->get_node();
+		$node_slides->method( 'translate' )->with( $slides_data, $lang, $source_lang )
+			->willReturn( $translated_slides_data );
+
+		$node_provider = $this->get_node_provider();
+		$node_provider->method( 'get' )->willReturnMap(
+			array(
+				array( 'image', $node_image ),
+				array( 'slides', $node_slides ),
+				array( 'not-supported', null ),
+			)
+		);
+
+		$subject = $this->get_subject( $node_provider );
+
+		$this->assertEquals( $expected_data, $subject->translate( $data, $lang, $source_lang ) );
+	}
+
+	private function get_subject( $node_provider ) {
+		return new WPML_Elementor_Media_Nodes_Iterator( $node_provider );
+	}
+
+	private function get_node_provider() {
+		return $this->getMockBuilder( 'WPML_Elementor_Media_Node_Provider' )
+			->setMethods( array( 'get' ) )->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_node() {
+		return $this->getMockBuilder( 'WPML_Elementor_Media_Node' )
+		            ->setMethods( array( 'translate' ) )->disableOriginalConstructor()->getMock();
+	}
+}
+
+if ( ! interface_exists( 'IWPML_PB_Media_Nodes_Iterator' ) ) {
+	interface IWPML_PB_Media_Nodes_Iterator {}
+}

--- a/tests/phpunit/tests/media/test-wpml-elementor-update-media-factory.php
+++ b/tests/phpunit/tests/media/test-wpml-elementor-update-media-factory.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Elementor_Update_Media_Factory extends OTGS_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		\Mockery::mock( 'alias:WPML_Page_Builders_Update_Media' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_iwpml_pb_media_update_factory() {
+		$subject = new WPML_Elementor_Update_Media_Factory();
+		$this->assertInstanceOf( 'IWPML_PB_Media_Update_Factory', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_an_instance_of_page_builders_media_update() {
+		$subject = new WPML_Elementor_Update_Media_Factory();
+		$this->assertInstanceOf( 'WPML_Page_Builders_Update_Media', $subject->create() );
+	}
+}
+
+if ( ! interface_exists( 'IWPML_PB_Media_Update_Factory' ) ) {
+	interface IWPML_PB_Media_Update_Factory {}
+}


### PR DESCRIPTION
I followed the same strategy as for Beaver Builder (https://github.com/OnTheGoSystems/wpml-page-builders-beaver-builder/pull/10 and https://github.com/OnTheGoSystems/wpml-page-builders/pull/24).

There's a lot of code (including the tests), but it does not make sense to split the task and it will be easier to run manual tests at once. Here are the most important parts:
- `WPML_Elementor_Media_Node_Provider` will provide node translators based on the type of element. It's easily extendable.
- `WPML_Elementor_Media_Nodes_Iterator` will iterate over all content nodes and will try to translate media nodes.
- `WPML_Elementor_Media_Node` is the base class for all the node translators.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5794