### PR TITLE
Only save post body as plain text if page has elementor data

### DIFF
--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -42,7 +42,9 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	}
 
 	public function save_post_body_as_plain_text( $type, $post_id, $original_post, $string_translations, $lang ) {
-		$this->elementor_db->save_plain_text( $post_id );
+		if ( get_post_meta( $post_id, $this->get_meta_field() ) ) {
+			$this->elementor_db->save_plain_text( $post_id );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/test-wpml-elementor-data-settings.php
+++ b/tests/phpunit/tests/test-wpml-elementor-data-settings.php
@@ -142,4 +142,43 @@ class Test_WPML_Elementor_Data_Settings extends OTGS_TestCase {
 
 		$this->assertEquals( $expected, $subject->add_data_custom_field_to_md5( $custom_field_values, $post_id ) );
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_saves_post_body_as_plain_text_when_elementor_page() {
+		$post_id = 123;
+
+		$elementor_db = \Mockery::mock( 'WPML_Elementor_DB' );
+		$elementor_db->shouldReceive( 'save_plain_text' )->once()->with( $post_id );
+
+		\WP_Mock::userFunction( 'get_post_meta', array(
+			'args' => array( $post_id, '_elementor_data' ),
+			'return' => true,
+		));
+
+		$subject = new WPML_Elementor_Data_Settings( $elementor_db );
+		$subject->save_post_body_as_plain_text( '', $post_id, '', '', '' );
+
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_saves_post_body_as_plain_text_when_not_an_elementor_page() {
+		$post_id = 123;
+
+		$elementor_db = \Mockery::mock( 'WPML_Elementor_DB' );
+		$elementor_db->shouldReceive( 'save_plain_text' )->never()->with( $post_id );
+
+		\WP_Mock::userFunction( 'get_post_meta', array(
+			'args' => array( $post_id, '_elementor_data' ),
+			'return' => false,
+		));
+
+		$subject = new WPML_Elementor_Data_Settings( $elementor_db );
+		$subject->save_post_body_as_plain_text( '', $post_id, '', '', '' );
+
+	}
+
 }


### PR DESCRIPTION
Only save post body as plain text if page has elementor data - https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5841