### PR TITLE
Replace the CSS class ID with the original for the global widget

### DIFF
--- a/src/class-wpml-elementor-adjust-global-widget-id.php
+++ b/src/class-wpml-elementor-adjust-global-widget-id.php
@@ -27,6 +27,7 @@ class WPML_Elementor_Adjust_Global_Widget_ID {
 	public function add_hooks() {
 		add_action( 'elementor/editor/before_enqueue_scripts', array( $this, 'adjust_ids' ) );
 		add_action( 'elementor/editor/after_enqueue_scripts', array( $this, 'restore_current_language' ) );
+		add_action( 'elementor/frontend/the_content', array( $this, 'replace_css_class_id_with_original' ) );
 
 		if ( is_admin() ) {
 			add_filter(
@@ -123,4 +124,20 @@ class WPML_Elementor_Adjust_Global_Widget_ID {
 		return $display_as_translated;
 	}
 
+	public function replace_css_class_id_with_original( $content ) {
+		return preg_replace_callback( '/(class=".*elementor-global-)(\d+)*/', array( $this, 'convert_id_to_original' ), $content );
+	}
+
+	private function convert_id_to_original( array $matches ) {
+		$id      = (int) $matches[2];
+		$element = $this->translation_element_factory->create_post( $id );
+		$source  = $element->get_source_element();
+
+		if ( $source ) {
+			$before_id  = $matches[1];
+			$matches[0] = str_replace( $before_id . $id, $before_id . $source->get_id(), $matches[0] );
+		}
+
+		return $matches[0];
+	}
 }

--- a/tests/phpunit/tests/test-wpml-elementor-adjust-global-widget-id.php
+++ b/tests/phpunit/tests/test-wpml-elementor-adjust-global-widget-id.php
@@ -35,7 +35,7 @@ class Test_WPML_Elementor_Adjust_Global_Widget_ID extends OTGS_TestCase {
 		), 10 );
 		$this->expectActionAdded( 'elementor/frontend/the_content', array(
 			$subject,
-			'replace_css_class_id_with_origina'
+			'replace_css_class_id_with_original'
 		), 10 );
 
 		$this->expectFilterAdded( 'wpml_should_use_display_as_translated_snippet', array(
@@ -70,7 +70,7 @@ class Test_WPML_Elementor_Adjust_Global_Widget_ID extends OTGS_TestCase {
 		), 10 );
 		$this->expectActionAdded( 'elementor/frontend/the_content', array(
 			$subject,
-			'replace_css_class_id_with_origina'
+			'replace_css_class_id_with_original'
 		), 10 );
 
 		$this->expectFilterAdded( 'wpml_should_use_display_as_translated_snippet', array(


### PR DESCRIPTION
The CSS class `elementor-global-{translated_id}` will be replaced with `elementor-global-{original_id}`.

Note: Elementor is creating dynamic CSS files located in `wp-content/uploads/elementor/css`, but I didn't find an easy way to adjust the CSS class there.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6006