### PR TITLE
Change the filter name for `elementor/theme/get_location_templates/condition_sub_id`

### DIFF
--- a/src/class-wpml-elementor-translate-ids.php
+++ b/src/class-wpml-elementor-translate-ids.php
@@ -11,7 +11,7 @@ class WPML_Elementor_Translate_IDs implements IWPML_Action {
 
 	public function add_hooks() {
 		add_filter( 'elementor/theme/get_location_templates/template_id', array( $this, 'translate_theme_location_template_id' ) );
-		add_filter( 'elementor/theme/get_location_templates/sub_id', array( $this, 'translate_location_condition_sub_id' ), 10, 2 );
+		add_filter( 'elementor/theme/get_location_templates/condition_sub_id', array( $this, 'translate_location_condition_sub_id' ), 10, 2 );
 		add_filter( 'elementor/documents/get/post_id', array(
 			$this,
 			'translate_template_id'

--- a/tests/phpunit/tests/test-wpml-elementor-translate-ids.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translate-ids.php
@@ -13,7 +13,7 @@ class Test_WPML_Elementor_Translate_IDs extends OTGS_TestCase {
 			$subject,
 			'translate_theme_location_template_id'
 		), 10 );
-		$this->expectFilterAdded( 'elementor/theme/get_location_templates/sub_id', array(
+		$this->expectFilterAdded( 'elementor/theme/get_location_templates/condition_sub_id', array(
 			$subject,
 			'translate_location_condition_sub_id'
 		), 10, 2 );


### PR DESCRIPTION
The filter that we agreed in wpmlcore-5647 is not the one release in Elementor 2.2.0.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6112