### PR TITLE
Elementor Pro - Unable to translate the pagination strings - Next Previous

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -651,6 +651,16 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 						'editor_type' => 'LINE'
 					),
 					array(
+						'field'       => 'pagination_prev_label',
+						'type'        => __( 'Posts: Previous Label', 'sitepress' ),
+						'editor_type' => 'LINE'
+					),
+					array(
+						'field'       => 'pagination_next_label',
+						'type'        => __( 'Posts: Next Label', 'sitepress' ),
+						'editor_type' => 'LINE'
+					),
+					array(
 						'field'       => 'cards_read_more_text',
 						'type'        => __( 'Posts: Cards Read more text', 'sitepress' ),
 						'editor_type' => 'LINE'


### PR DESCRIPTION
When you use the Posts widget and add the pagination, the "Next" and "Previous" strings are not translated.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5968