### PR TITLE
Fix maintenance template query

### DIFF
--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -20,6 +20,7 @@ class WPML_Elementor_Integration_Factory {
 				'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
 				'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
 				'WPML_Elementor_Media_Hooks_Factory',
+				'WPML_PB_Fix_Maintenance_Query_Factory',
 			)
 		);
 

--- a/src/class-wpml-pb-fix-maintenance-query-factory.php
+++ b/src/class-wpml-pb-fix-maintenance-query-factory.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_PB_Fix_Maintenance_Query_Factory implements IWPML_Frontend_Action_Loader {
+
+	public function create() {
+		return new WPML_PB_Fix_Maintenance_Query();
+	}
+}

--- a/src/class-wpml-pb-fix-maintenance-query.php
+++ b/src/class-wpml-pb-fix-maintenance-query.php
@@ -1,0 +1,16 @@
+<?php
+
+class WPML_PB_Fix_Maintenance_Query {
+
+	const AFTER_TEMPLATE_APPLY = 12;
+
+	public function add_hooks() {
+		add_action( 'template_redirect', array( $this, 'fix_global_query' ), self::AFTER_TEMPLATE_APPLY );
+	}
+
+	public function fix_global_query() {
+		if ( (int) \Elementor\Maintenance_Mode::get( 'template_id' ) === $GLOBALS['post']->ID ) {
+			$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'];
+		}
+	}
+}

--- a/tests/phpunit/tests/test-pb-fix-maintenance-query.php
+++ b/tests/phpunit/tests/test-pb-fix-maintenance-query.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Class Test_WPML_PB_Fix_Maintenance_Query
+ *
+ * @group wpmlcore-5239
+ */
+class Test_WPML_PB_Fix_Maintenance_Query extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_adds_hooks() {
+		$subject = new WPML_PB_Fix_Maintenance_Query();
+		\WP_Mock::expectActionAdded( 'template_redirect', array( $subject, 'fix_global_query' ), 12 );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_fixes_global_query() {
+		$original_post = new stdClass();
+		$template_post = new stdClass();
+		$template_id   = 3;
+
+		$post_backup      = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+		$the_query_backup = isset( $GLOBALS['wp_the_query'] ) ? $GLOBALS['wp_the_query'] : null;
+		$query_backup     = isset( $GLOBALS['wp_query'] ) ? $GLOBALS['wp_query'] : null;
+
+		$GLOBALS['post']         = $template_post;
+		$GLOBALS['post']->ID     = $template_id;
+		$GLOBALS['wp_the_query'] = $original_post;
+		$GLOBALS['wp_query']     = $template_post;
+
+		$subject = new WPML_PB_Fix_Maintenance_Query();
+
+		\mockery::mock( 'overload:' . \Elementor\Maintenance_Mode::class )
+		        ->shouldReceive( 'get' )
+		        ->with( 'template_id' )
+		        ->andReturn( $template_id );
+
+		$subject->fix_global_query();
+		$this->assertEquals( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
+
+		$GLOBALS['post']         = $post_backup;
+		$GLOBALS['wp_the_query'] = $the_query_backup;
+		$GLOBALS['post']         = $post_backup;
+		$GLOBALS['wp_query']     = $query_backup;
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -21,11 +21,12 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 		$action_filter_loader->shouldReceive( 'load' )
 		                     ->once()
 		                     ->with( array(
-								'WPML_Elementor_Translate_IDs_Factory',
-								'WPML_Elementor_URLs_Factory',
-								'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
-								'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
-								'WPML_Elementor_Media_Hooks_Factory',
+			                     'WPML_Elementor_Translate_IDs_Factory',
+			                     'WPML_Elementor_URLs_Factory',
+			                     'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
+			                     'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
+			                     'WPML_Elementor_Media_Hooks_Factory',
+			                     'WPML_PB_Fix_Maintenance_Query_Factory',
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );

--- a/tests/phpunit/tests/test-wpml-pb-fix-maintenance-query-factory.php
+++ b/tests/phpunit/tests/test-wpml-pb-fix-maintenance-query-factory.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class Test_WPML_PB_Fix_Maintenance_Query_Factory
+ *
+ * @group wpmlcore-5239
+ */
+class Test_WPML_PB_Fix_Maintenance_Query_Factory extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_runs_on_front_end_requests() {
+		$subject = new WPML_PB_Fix_Maintenance_Query_Factory();
+		$this->assertInstanceOf( 'IWPML_Frontend_Action_Loader', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_instance_of_fix_maintenance_query() {
+		$subject = new WPML_PB_Fix_Maintenance_Query_Factory();
+		$this->assertInstanceOf( 'WPML_PB_Fix_Maintenance_Query', $subject->create() );
+	}
+}


### PR DESCRIPTION
This fix is needed because WPML is calling `wp_reset_query` in `\SitePress::get_ls_languages` which happens after Elementor adjusted the query for displaying the coming soon template.

The `wp_reset_query` basically restores the global `wp_the_query`. So, we must adjust it before WPML calls the function.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5239