### PR TITLE
Fix PHP notice thrown when `$post` global is `null`

### DIFF
--- a/src/class-wpml-pb-fix-maintenance-query.php
+++ b/src/class-wpml-pb-fix-maintenance-query.php
@@ -11,6 +11,7 @@ class WPML_PB_Fix_Maintenance_Query {
 	public function fix_global_query() {
 		if (
 			class_exists( '\Elementor\Maintenance_Mode' ) &&
+			isset( $GLOBALS['post']->ID ) &&
 			(int) \Elementor\Maintenance_Mode::get( 'template_id' ) === $GLOBALS['post']->ID
 		) {
 			$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'];

--- a/tests/phpunit/tests/test-pb-fix-maintenance-query.php
+++ b/tests/phpunit/tests/test-pb-fix-maintenance-query.php
@@ -18,6 +18,40 @@ class Test_WPML_PB_Fix_Maintenance_Query extends OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6218
+	 */
+	public function it_does_not_fix_global_query_if_post_is_not_set() {
+		$original_post = new stdClass();
+		$template_post = new stdClass();
+		$template_id   = 3;
+
+		$post_backup      = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+		$the_query_backup = isset( $GLOBALS['wp_the_query'] ) ? $GLOBALS['wp_the_query'] : null;
+		$query_backup     = isset( $GLOBALS['wp_query'] ) ? $GLOBALS['wp_query'] : null;
+
+		$GLOBALS['post']         = null;
+		$GLOBALS['wp_the_query'] = $original_post;
+		$GLOBALS['wp_query']     = $template_post;
+
+		$subject = new WPML_PB_Fix_Maintenance_Query();
+
+		\mockery::mock( 'overload:' . \Elementor\Maintenance_Mode::class )
+		        ->shouldReceive( 'get' )
+		        ->with( 'template_id' )
+		        ->andReturn( $template_id );
+
+		$subject->fix_global_query();
+		$this->assertEquals( $original_post, $GLOBALS['wp_the_query'] );
+		$this->assertEquals( $template_post, $GLOBALS['wp_query'] );
+
+		$GLOBALS['post']         = $post_backup;
+		$GLOBALS['wp_the_query'] = $the_query_backup;
+		$GLOBALS['post']         = $post_backup;
+		$GLOBALS['wp_query']     = $query_backup;
+	}
+
+	/**
+	 * @test
 	 */
 	public function it_fixes_global_query() {
 		$original_post = new stdClass();


### PR DESCRIPTION
Happens on the native post edit screen (block editor).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6218