### PR TITLE
Elementor Price List description needs to be set to Area instead of Visual

### DIFF
--- a/src/modules/class-wpml-elementor-price-list.php
+++ b/src/modules/class-wpml-elementor-price-list.php
@@ -55,7 +55,7 @@ class WPML_Elementor_Price_List extends WPML_Elementor_Module_With_Items {
 		}
 
 		if ( 'item_description' === $field ) {
-			return 'VISUAL';
+			return 'AREA';
 		}
 
 		return '';

--- a/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
@@ -294,7 +294,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 				'price_list',
 				array(
 					array( 'field' => 'title', 'value' => rand_str( 10 ), 'type' => 'Price list: title', 'editor_type' => 'LINE' ),
-					array( 'field' => 'item_description', 'value' => rand_str( 10 ), 'type' => 'Pricing list: description', 'editor_type' => 'VISUAL' ),
+					array( 'field' => 'item_description', 'value' => rand_str( 10 ), 'type' => 'Pricing list: description', 'editor_type' => 'AREA' ),
 					'link' => array( 'field' => 'url', 'value' => rand_str( 10 ), 'type' => 'Pricing list: link', 'editor_type' => 'LINK' ),
 
 				),


### PR DESCRIPTION
When you translate a price list widget by Elementor, an addition <p> tag will be added to the description due to the fact the description editor is set to Visual and it should be just Area.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6237