### PR TITLE
Fixed PHP warning when dealing with _elementor_css field

### DIFF
--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -35,7 +35,13 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 */
 	public function mark_css_field_as_empty( $value, $translated_post_id, $original_post_id, $meta_key ) {
 		if ( '_elementor_css' === $meta_key ) {
-			$value['status'] = '';
+			if ( ! isset( $value['status'] ) ) {
+				$value           = current( $value );
+				$value['status'] = '';
+				$value           = array( $value );
+			} else {
+				$value['status'] = '';
+			}
 		}
 
 		return $value;

--- a/tests/phpunit/tests/test-wpml-elementor-data-settings.php
+++ b/tests/phpunit/tests/test-wpml-elementor-data-settings.php
@@ -31,11 +31,39 @@ class Test_WPML_Elementor_Data_Settings extends OTGS_TestCase {
 		$subject->add_hooks();
 	}
 
-	public function it_marks_css_field_as_empty() {
+	/**
+	 * @test
+	 *
+	 * @group wpmlcore-6319
+	 */
+	public function it_marks_css_field_as_empty_when_status_is_in_another_array_level() {
 		$subject = new WPML_Elementor_Data_Settings();
-		$this->assertEquals( '', $subject->mark_css_field_as_empty( rand_str( 10 ), null, null, '_elementor_css' ) );
+
+		$value         = array( array( 'status' => 'something' ) );
+		$changed_value = array( array( 'status' => '' ) );
+
+		$this->assertEquals( $changed_value, $subject->mark_css_field_as_empty( $value, null, null, '_elementor_css' ) );
 	}
 
+	/**
+	 * @test
+	 *
+	 * @group wpmlcore-6319
+	 */
+	public function it_marks_css_field_as_empty_when_status_is_in_the_single_level() {
+		$subject = new WPML_Elementor_Data_Settings();
+
+		$value         = array( 'status' => 'something' );
+		$changed_value = array( 'status' => '' );
+
+		$this->assertEquals( $changed_value, $subject->mark_css_field_as_empty( $value, null, null, '_elementor_css' ) );
+	}
+
+	/**
+	 * @test
+	 *
+	 * @group wpmlcore-6319
+	 */
 	public function it_does_not_mark_css_field_as_empty() {
 		$subject = new WPML_Elementor_Data_Settings();
 		$value = rand_str( 10 );


### PR DESCRIPTION
The problem happens because there is another indexed level inside of the field value (apparently changed recently on Elementor, not sure though).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6319