### PR TITLE
Mark headings in XLIFFs so that ATE can indicate that these fields have SEO significance.

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -152,6 +152,13 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
+		if ( 'heading' === $settings[ $this->type ] ) {
+			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : '';
+			if ( $header_size ) {
+				return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id . '-' . $header_size;
+			}
+		}
+
 		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
 	}
 

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -32,7 +32,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	}
 
 	/**
-	 * @param string|int $node_id
+	 * @param string|int $node_id Translatable node id.
 	 * @param array $element
 	 *
 	 * @return WPML_PB_String[]
@@ -55,7 +55,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$element[ $this->settings_field ][ $field_key ],
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
-							$field['editor_type']
+							$field['editor_type'],
+							$this->get_string_wrap( $element )
 						);
 						$strings[] = $string;
 					} else if ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
@@ -63,7 +64,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$element[ $this->settings_field ][ $key ][ $field_key ],
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
-							$field['editor_type']
+							$field['editor_type'],
+							$this->get_string_wrap( $element )
 						);
 						$strings[] = $string;
 					}
@@ -152,14 +154,25 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
-		if ( 'heading' === $settings[ $this->type ] ) {
-			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : '';
-			if ( $header_size ) {
-				return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id . '-' . $header_size;
-			}
+		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
+	}
+
+	/**
+	 * Get wrap tag for string.
+	 *
+	 * @param array $settings Field settings.
+	 *
+	 * @return string
+	 */
+	public function get_string_wrap( $settings ) {
+		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
+			// h2 must be by default, as Elementor sends empty header size for h2 block.
+			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : 'h2';
+
+			return $header_size;
 		}
 
-		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
+		return '';
 	}
 
 	/**

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -56,7 +56,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
 							$field['editor_type'],
-							$this->get_string_wrap( $element )
+							$this->get_wrap_tag( $element )
 						);
 						$strings[] = $string;
 					} else if ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
@@ -65,7 +65,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
 							$field['editor_type'],
-							$this->get_string_wrap( $element )
+							$this->get_wrap_tag( $element )
 						);
 						$strings[] = $string;
 					}
@@ -159,12 +159,13 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 
 	/**
 	 * Get wrap tag for string.
+	 * Used for SEO, can contain (h1...h6, etc.)
 	 *
 	 * @param array $settings Field settings.
 	 *
 	 * @return string
 	 */
-	public function get_string_wrap( $settings ) {
+	private function get_wrap_tag( $settings ) {
 		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
 			// h2 must be by default, as Elementor sends empty header size for h2 block.
 			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : 'h2';

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -6,7 +6,10 @@
 class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translatable_Nodes {
 
 	const SETTINGS_FIELD = 'settings';
-	const TYPE           = 'widgetType';
+
+	const TYPE = 'widgetType';
+
+	const DEFAULT_HEADING_TAG = 'h2';
 
 	/**
 	 * @var string
@@ -167,8 +170,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 */
 	private function get_wrap_tag( $settings ) {
 		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
-			// h2 must be by default, as Elementor sends empty header size for h2 block.
-			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : 'h2';
+			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ?
+				$settings[ $this->settings_field ]['header_size'] : self::DEFAULT_HEADING_TAG;
 
 			return $header_size;
 		}

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -5,10 +5,8 @@
  */
 class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translatable_Nodes {
 
-	const SETTINGS_FIELD = 'settings';
-
-	const TYPE = 'widgetType';
-
+	const SETTINGS_FIELD      = 'settings';
+	const TYPE                = 'widgetType';
 	const DEFAULT_HEADING_TAG = 'h2';
 
 	/**

--- a/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
@@ -17,7 +17,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 	 * @param $fields
 	 */
 	public function it_gets( $type, $fields, $items_field, $items ) {
-		$node_id = rand_str( 10 );
+		$node_id  = rand_str( 10 );
 		$settings = array();
 
 		foreach ( $fields as $key => $field ) {
@@ -26,8 +26,8 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 			} else {
 				$settings[ $key ] = array(
 					$field['field'] => rand_str( 10 ),
-					'type' => $field['type'],
-					'editor_type' => $field['editor_type'],
+					'type'          => $field['type'],
+					'editor_type'   => $field['editor_type'],
 				);
 			}
 		}
@@ -43,13 +43,17 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 			}
 		}
 
-		$sub_items[ '_id' ] = mt_rand( 1, 10 );
+		$sub_items['_id'] = mt_rand( 1, 10 );
 		$settings[ $items_field ][] = $sub_items;
 
+		if ( 'heading' === $type ) {
+			$settings['header_size'] = 'h1';
+		}
+
 		$element = array(
-			'id' => $node_id,
+			'id'         => $node_id,
 			'widgetType' => $type,
-			'settings' => $settings,
+			'settings'   => $settings,
 		);
 
 		\WP_Mock::wpPassthruFunction( '__' );
@@ -82,9 +86,12 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 			if ( is_numeric( $key ) ) {
 				$string = $strings[ $key ];
 				$this->assertEquals( $element['settings'][ $field['field'] ], $string->get_value() );
-				$this->assertEquals( $field['field'] . '-' . $element[ 'widgetType'] . '-' . $node_id, $string->get_name() );
+				$this->assertEquals( $field['field'] . '-' . $element['widgetType'] . '-' . $node_id, $string->get_name() );
 				$this->assertEquals( $field['type'], $string->get_title() );
 				$this->assertEquals( $field['editor_type'], $string->get_editor_type() );
+				if ( 'heading' === $type ) {
+					$this->assertEquals( $element['settings']['header_size'], $string->get_wrap_tag() );
+				}
 			} else {
 				$string = $strings[0];
 				if ( 'button' === $type ) {
@@ -112,7 +119,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 				}
 
 				$this->assertEquals( $element['settings'][ $key ][ $field['field'] ], $string->get_value() );
-				$this->assertEquals( $field['field'] . '-' . $element[ 'widgetType'] . '-' . $node_id, $string->get_name() );
+				$this->assertEquals( $field['field'] . '-' . $element['widgetType'] . '-' . $node_id, $string->get_name() );
 				$this->assertEquals( $field['type'], $string->get_title() );
 				$this->assertEquals( $field['editor_type'], $string->get_editor_type() );
 			}
@@ -125,7 +132,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 				if ( is_numeric( $item_key ) ) {
 					$this->assertEquals( $element['settings'][ $items_field ][0][ $item['field'] ], $string->get_value() );
-					$this->assertEquals( $element['widgetType'] . '-' . $item['field'] . '-' . $node_id . '-' . $sub_items[ '_id' ], $string->get_name() );
+					$this->assertEquals( $element['widgetType'] . '-' . $item['field'] . '-' . $node_id . '-' . $sub_items['_id'], $string->get_name() );
 				} else {
 					$this->assertEquals( $element['settings'][ $items_field ][0][ $item_key ][ $item['field'] ], $string->get_value() );
 				}


### PR DESCRIPTION
Changes in wpml-page-builders-elementor to support task of the ticket.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-3081