### PR TITLE
Introduce `field_id` to differenciate 2 occurrences of the same field in a node

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -159,7 +159,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
-		return $field['field'] . '-' . $settings[ self::TYPE ] . '-' . $node_id;
+		$field_id = isset( $field['field_id'] ) ? $field['field_id'] : $field['field'];
+		return $field_id . '-' . $settings[ self::TYPE ] . '-' . $node_id;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -26,7 +26,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
 			                     'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
 			                     'WPML_Elementor_Media_Hooks_Factory',
-								 'WPML_Elementor_WooCommerce_Hooks_Factory',
+			                     'WPML_Elementor_WooCommerce_Hooks_Factory',
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );


### PR DESCRIPTION
I started trying to dynamically detect multiple occurrences, and then automatically affect an extra suffix (except for the first one). But this was not working on the update part, because the strings will not necessarily be in the same order. Finally, I decided to introduce a new `field_wrapper` which will provide the actual name of the field to be used in the string.

This change will not affect existing strings and backward compatibility.

https://github.com/OnTheGoSystems/wpml-page-builders-elementor/issues/64
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6436