### PR TITLE
Improve code to not rely on numeric keys of the field definition 

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -49,28 +49,26 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 		foreach ( $this->nodes_to_translate as $node_type => $node_data ) {
 			if ( $this->conditions_ok( $node_data, $element ) ) {
 				foreach ( $node_data['fields'] as $key => $field ) {
-					$field_key = $field['field'];
+					$field_key    = $field['field'];
+					$string_value = null;
 
-					if ( is_numeric( $key ) && isset( $element[ $this->settings_field ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $field_key ] ) ) {
-						$string    = new WPML_PB_String(
-							$element[ $this->settings_field ][ $field_key ],
+					if ( isset( $element[ $this->settings_field ][ $field_key ] ) && is_string( $element[ $this->settings_field ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $field_key ] ) ) {
+						$string_value = $element[ $this->settings_field ][ $field_key ];
+					} elseif ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
+						$string_value =	$element[ $this->settings_field ][ $key ][ $field_key ];
+					}
+
+					if ( $string_value ) {
+						$strings[] = new WPML_PB_String(
+							$string_value,
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
 							$field['editor_type'],
 							$this->get_wrap_tag( $element )
 						);
-						$strings[] = $string;
-					} else if ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
-						$string    = new WPML_PB_String(
-							$element[ $this->settings_field ][ $key ][ $field_key ],
-							$this->get_string_name( $node_id, $field, $element ),
-							$field['type'],
-							$field['editor_type'],
-							$this->get_wrap_tag( $element )
-						);
-						$strings[] = $string;
 					}
 				}
+
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
@@ -106,7 +104,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 					$field_key = $field['field'];
 
 					if ( $this->get_string_name( $node_id, $field, $element ) === $string->get_name() ) {
-						if ( is_numeric( $key ) ) {
+						if ( isset( $element[ $this->settings_field ][ $field_key ] ) && is_string( $element[ $this->settings_field ][ $field_key ] ) ) {
 							$element[ $this->settings_field ][ $field_key ] = $string->get_value();
 						} else {
 							$element[ $this->settings_field ][ $key ][ $field_key ] = $string->get_value();

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -10,27 +10,9 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	const DEFAULT_HEADING_TAG = 'h2';
 
 	/**
-	 * @var string
-	 */
-	private $settings_field;
-
-	/**
-	 * @var string
-	 */
-	private $type;
-
-	/**
 	 * @var array
 	 */
 	private $nodes_to_translate;
-
-	/**
-	 * WPML_Elementor_Translatable_Nodes constructor.
-	 */
-	public function __construct() {
-		$this->settings_field = self::SETTINGS_FIELD;
-		$this->type           = 'widgetType';
-	}
 
 	/**
 	 * @param string|int $node_id Translatable node id.
@@ -52,10 +34,10 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 					$field_key    = $field['field'];
 					$string_value = null;
 
-					if ( isset( $element[ $this->settings_field ][ $field_key ] ) && is_string( $element[ $this->settings_field ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $field_key ] ) ) {
-						$string_value = $element[ $this->settings_field ][ $field_key ];
-					} elseif ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
-						$string_value =	$element[ $this->settings_field ][ $key ][ $field_key ];
+					if ( isset( $element[ self::SETTINGS_FIELD ][ $field_key ] ) && is_string( $element[ self::SETTINGS_FIELD ][ $field_key ] ) && trim( $element[ self::SETTINGS_FIELD ][ $field_key ] ) ) {
+						$string_value = $element[ self::SETTINGS_FIELD ][ $field_key ];
+					} elseif ( isset( $element[ self::SETTINGS_FIELD ][ $key ][ $field_key ] ) && trim( $element[ self::SETTINGS_FIELD ][ $key ][ $field_key ] ) ) {
+						$string_value =	$element[ self::SETTINGS_FIELD ][ $key ][ $field_key ];
 					}
 
 					if ( $string_value ) {
@@ -104,10 +86,10 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 					$field_key = $field['field'];
 
 					if ( $this->get_string_name( $node_id, $field, $element ) === $string->get_name() ) {
-						if ( isset( $element[ $this->settings_field ][ $field_key ] ) && is_string( $element[ $this->settings_field ][ $field_key ] ) ) {
-							$element[ $this->settings_field ][ $field_key ] = $string->get_value();
+						if ( isset( $element[ self::SETTINGS_FIELD ][ $field_key ] ) && is_string( $element[ self::SETTINGS_FIELD ][ $field_key ] ) ) {
+							$element[ self::SETTINGS_FIELD ][ $field_key ] = $string->get_value();
 						} else {
-							$element[ $this->settings_field ][ $key ][ $field_key ] = $string->get_value();
+							$element[ self::SETTINGS_FIELD ][ $key ][ $field_key ] = $string->get_value();
 						}
 					}
 				}
@@ -117,7 +99,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$node = new $class();
 							$item = $node->update( $node_id, $element, $string );
 							if ( $item ) {
-								$element[ $this->settings_field ][ $node->get_items_field() ][ $item['index'] ] = $item;
+								$element[ self::SETTINGS_FIELD ][ $node->get_items_field() ][ $item['index'] ] = $item;
 							}
 						} catch ( Exception $e ) {
 
@@ -153,7 +135,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
-		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
+		return $field['field'] . '-' . $settings[ self::TYPE ] . '-' . $node_id;
 	}
 
 	/**
@@ -165,9 +147,9 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	private function get_wrap_tag( $settings ) {
-		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
-			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ?
-				$settings[ $this->settings_field ]['header_size'] : self::DEFAULT_HEADING_TAG;
+		if ( isset( $settings[ self::TYPE ] ) && 'heading' === $settings[ self::TYPE ] ) {
+			$header_size = isset( $settings[ self::SETTINGS_FIELD ]['header_size'] ) ?
+				$settings[ self::SETTINGS_FIELD ]['header_size'] : self::DEFAULT_HEADING_TAG;
 
 			return $header_size;
 		}


### PR DESCRIPTION
So far, we were assuming that numeric keys for the field definition were
matching with string value in the element field. And non-numeric keys
were matching with array fields. This was implicit but
not documented, and this is not correct IMO. We should rather check wether
the actual field is a string or an array instead.

The code is already covered with tests (so backward compatible) and I
added some more tests.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6442

I added a second commit (07cf0c5) to get rid of 2 private properties which are actually constants.