### PR TITLE
Improve code to not rely on numeric keys of the field definition

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -159,7 +159,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
-		return $field['field'] . '-' . $settings[ self::TYPE ] . '-' . $node_id;
+		$field_id = isset( $field['field_id'] ) ? $field['field_id'] : $field['field'];
+		return $field_id . '-' . $settings[ self::TYPE ] . '-' . $node_id;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -26,7 +26,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
 			                     'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
 			                     'WPML_Elementor_Media_Hooks_Factory',
-								 'WPML_Elementor_WooCommerce_Hooks_Factory',
+			                     'WPML_Elementor_WooCommerce_Hooks_Factory',
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );


### PR DESCRIPTION
So far, we were assuming that numeric keys for the field definition were
matching with string value in the element field. And non-numeric keys
were matching with array fields. This was implicit but
not documented, and this is not correct IMO. We should rather check wether
the actual field is a string or an array instead.

The code is already covered with tests (so backward compatible) and I
added some more tests.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6442

I added a second commit (07cf0c5) to get rid of 2 private properties which are actually constants.