### PR TITLE
make it possible to pass an instance of an integration class

### DIFF
--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -34,7 +34,7 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 * @return mixed
 	 */
 	public function mark_css_field_as_empty( $value, $translated_post_id, $original_post_id, $meta_key ) {
-		if ( '_elementor_css' === $meta_key ) {
+		if ( '_elementor_css' === $meta_key && is_array( $value ) ) {
 			if ( ! isset( $value['status'] ) ) {
 				$value           = current( $value );
 				$value['status'] = '';

--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -35,7 +35,13 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 */
 	public function mark_css_field_as_empty( $value, $translated_post_id, $original_post_id, $meta_key ) {
 		if ( '_elementor_css' === $meta_key ) {
-			$value['status'] = '';
+			if ( ! isset( $value['status'] ) ) {
+				$value           = current( $value );
+				$value['status'] = '';
+				$value           = array( $value );
+			} else {
+				$value['status'] = '';
+			}
 		}
 
 		return $value;

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -152,6 +152,13 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
+		if ( 'heading' === $settings[ $this->type ] ) {
+			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : '';
+			if ( $header_size ) {
+				return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id . '-' . $header_size;
+			}
+		}
+
 		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
 	}
 

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -32,7 +32,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	}
 
 	/**
-	 * @param string|int $node_id
+	 * @param string|int $node_id Translatable node id.
 	 * @param array $element
 	 *
 	 * @return WPML_PB_String[]
@@ -55,7 +55,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$element[ $this->settings_field ][ $field_key ],
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
-							$field['editor_type']
+							$field['editor_type'],
+							$this->get_string_wrap( $element )
 						);
 						$strings[] = $string;
 					} else if ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
@@ -63,7 +64,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$element[ $this->settings_field ][ $key ][ $field_key ],
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
-							$field['editor_type']
+							$field['editor_type'],
+							$this->get_string_wrap( $element )
 						);
 						$strings[] = $string;
 					}
@@ -152,14 +154,25 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 * @return string
 	 */
 	public function get_string_name( $node_id, $field, $settings ) {
-		if ( 'heading' === $settings[ $this->type ] ) {
-			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : '';
-			if ( $header_size ) {
-				return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id . '-' . $header_size;
-			}
+		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
+	}
+
+	/**
+	 * Get wrap tag for string.
+	 *
+	 * @param array $settings Field settings.
+	 *
+	 * @return string
+	 */
+	public function get_string_wrap( $settings ) {
+		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
+			// h2 must be by default, as Elementor sends empty header size for h2 block.
+			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : 'h2';
+
+			return $header_size;
 		}
 
-		return $field['field'] . '-' . $settings[ $this->type ] . '-' . $node_id;
+		return '';
 	}
 
 	/**

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -56,7 +56,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
 							$field['editor_type'],
-							$this->get_string_wrap( $element )
+							$this->get_wrap_tag( $element )
 						);
 						$strings[] = $string;
 					} else if ( isset( $element[ $this->settings_field ][ $key ][ $field_key ] ) && trim( $element[ $this->settings_field ][ $key ][ $field_key ] ) ) {
@@ -65,7 +65,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 							$this->get_string_name( $node_id, $field, $element ),
 							$field['type'],
 							$field['editor_type'],
-							$this->get_string_wrap( $element )
+							$this->get_wrap_tag( $element )
 						);
 						$strings[] = $string;
 					}
@@ -159,12 +159,13 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 
 	/**
 	 * Get wrap tag for string.
+	 * Used for SEO, can contain (h1...h6, etc.)
 	 *
 	 * @param array $settings Field settings.
 	 *
 	 * @return string
 	 */
-	public function get_string_wrap( $settings ) {
+	private function get_wrap_tag( $settings ) {
 		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
 			// h2 must be by default, as Elementor sends empty header size for h2 block.
 			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : 'h2';

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -74,7 +74,11 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
-							$node    = new $class();
+							if($class instanceof \WPML_Elementor_Module_With_Items){
+								$node = $class;
+							} else {
+								$node = new $class();
+							}
 							$strings = $node->get( $node_id, $element, $strings );
 						} catch ( Exception $e ) {
 						}
@@ -116,7 +120,11 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
-							$node = new $class();
+							if($class instanceof \WPML_Elementor_Module_With_Items){
+								$node = $class;
+							} else {
+								$node = new $class();
+							}
 							$item = $node->update( $node_id, $element, $string );
 							if ( $item ) {
 								$element[ $this->settings_field ][ $node->get_items_field() ][ $item['index'] ] = $item;

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -74,7 +74,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
-							if($class instanceof \WPML_Elementor_Module_With_Items){
+							if( $class instanceof \WPML_Elementor_Module_With_Items ){
 								$node = $class;
 							} else {
 								$node = new $class();
@@ -120,7 +120,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
-							if($class instanceof \WPML_Elementor_Module_With_Items){
+							if ( $class instanceof \WPML_Elementor_Module_With_Items ){
 								$node = $class;
 							} else {
 								$node = new $class();

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -6,7 +6,10 @@
 class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translatable_Nodes {
 
 	const SETTINGS_FIELD = 'settings';
-	const TYPE           = 'widgetType';
+
+	const TYPE = 'widgetType';
+
+	const DEFAULT_HEADING_TAG = 'h2';
 
 	/**
 	 * @var string
@@ -167,8 +170,8 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 	 */
 	private function get_wrap_tag( $settings ) {
 		if ( isset( $settings[ $this->type ] ) && 'heading' === $settings[ $this->type ] ) {
-			// h2 must be by default, as Elementor sends empty header size for h2 block.
-			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ? $settings[ $this->settings_field ]['header_size'] : 'h2';
+			$header_size = isset( $settings[ $this->settings_field ]['header_size'] ) ?
+				$settings[ $this->settings_field ]['header_size'] : self::DEFAULT_HEADING_TAG;
 
 			return $header_size;
 		}

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -5,10 +5,8 @@
  */
 class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translatable_Nodes {
 
-	const SETTINGS_FIELD = 'settings';
-
-	const TYPE = 'widgetType';
-
+	const SETTINGS_FIELD      = 'settings';
+	const TYPE                = 'widgetType';
 	const DEFAULT_HEADING_TAG = 'h2';
 
 	/**

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -74,7 +74,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
-							if( $class instanceof \WPML_Elementor_Module_With_Items ){
+							if ( $class instanceof \WPML_Elementor_Module_With_Items ) {
 								$node = $class;
 							} else {
 								$node = new $class();
@@ -120,7 +120,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 				if ( isset( $node_data['integration-class'] ) ) {
 					foreach ( $this->get_integration_classes( $node_data ) as $class ) {
 						try {
-							if ( $class instanceof \WPML_Elementor_Module_With_Items ){
+							if ( $class instanceof \WPML_Elementor_Module_With_Items ) {
 								$node = $class;
 							} else {
 								$node = new $class();

--- a/src/class-wpml-elementor-woocommerce-hooks.php
+++ b/src/class-wpml-elementor-woocommerce-hooks.php
@@ -12,9 +12,9 @@ class WPML_Elementor_WooCommerce_Hooks {
 	 * @return WP_Query
 	 */
 	public function do_not_suppress_filters_on_product_widget( WP_Query $query ) {
-		if ( 'product' === $query->query_vars['post_type']
-		     && isset( $_POST['action'] )
-		     && 'elementor_ajax' === $_POST['action']
+		if (
+			array_key_exists( 'post_type', $query->query_vars ) && 'product' === $query->query_vars['post_type']
+			&& isset( $_POST['action'] ) && 'elementor_ajax' === $_POST['action']
 		) {
 			$query->query_vars['suppress_filters'] = false;
 		}

--- a/tests/phpunit/tests/test-wpml-elementor-data-settings.php
+++ b/tests/phpunit/tests/test-wpml-elementor-data-settings.php
@@ -72,6 +72,16 @@ class Test_WPML_Elementor_Data_Settings extends OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6400
+	 */
+	public function it_does_not_mark_css_field_as_empty_when_value_is_not_array() {
+		$subject = new WPML_Elementor_Data_Settings();
+		$value = rand_str( 10 );
+		$this->assertEquals( $value, $subject->mark_css_field_as_empty( $value, null, null, '_elementor_css' ) );
+	}
+
+	/**
+	 * @test
 	 */
 	public function it_gets_meta_field() {
 		$subject = new WPML_Elementor_Data_Settings();

--- a/tests/phpunit/tests/test-wpml-elementor-data-settings.php
+++ b/tests/phpunit/tests/test-wpml-elementor-data-settings.php
@@ -31,11 +31,39 @@ class Test_WPML_Elementor_Data_Settings extends OTGS_TestCase {
 		$subject->add_hooks();
 	}
 
-	public function it_marks_css_field_as_empty() {
+	/**
+	 * @test
+	 *
+	 * @group wpmlcore-6319
+	 */
+	public function it_marks_css_field_as_empty_when_status_is_in_another_array_level() {
 		$subject = new WPML_Elementor_Data_Settings();
-		$this->assertEquals( '', $subject->mark_css_field_as_empty( rand_str( 10 ), null, null, '_elementor_css' ) );
+
+		$value         = array( array( 'status' => 'something' ) );
+		$changed_value = array( array( 'status' => '' ) );
+
+		$this->assertEquals( $changed_value, $subject->mark_css_field_as_empty( $value, null, null, '_elementor_css' ) );
 	}
 
+	/**
+	 * @test
+	 *
+	 * @group wpmlcore-6319
+	 */
+	public function it_marks_css_field_as_empty_when_status_is_in_the_single_level() {
+		$subject = new WPML_Elementor_Data_Settings();
+
+		$value         = array( 'status' => 'something' );
+		$changed_value = array( 'status' => '' );
+
+		$this->assertEquals( $changed_value, $subject->mark_css_field_as_empty( $value, null, null, '_elementor_css' ) );
+	}
+
+	/**
+	 * @test
+	 *
+	 * @group wpmlcore-6319
+	 */
 	public function it_does_not_mark_css_field_as_empty() {
 		$subject = new WPML_Elementor_Data_Settings();
 		$value = rand_str( 10 );

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -26,6 +26,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
 			                     'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
 			                     'WPML_Elementor_Media_Hooks_Factory',
+								 'WPML_Elementor_WooCommerce_Hooks_Factory',
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );

--- a/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
@@ -433,6 +433,44 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 		$this->assertEquals( array( $string ), $subject->get( $node_id, $element_data ) );
 	}
 
+    /**
+     * @test
+     */
+    public function it_gets_single_repeater_field_using_integration_class_instance() {
+        $subject = new WPML_Elementor_Translatable_Nodes();
+        $field_id = 1;
+
+        $nodes = array(
+            'my-custom-module'      => array(
+                'conditions'        => array( 'widgetType' => 'my-custom-module' ),
+                'fields'            => array(),
+                'integration-class' => new WPML_PB_My_Custom_Module_With_A_Single_Repeater_Field(),
+            ),
+        );
+
+        \WP_Mock::onFilter( 'wpml_elementor_widgets_to_translate' )
+            ->with( WPML_Elementor_Translatable_Nodes::get_nodes_to_translate() )
+            ->reply( $nodes );
+
+        $element_data = array(
+            'widgetType' => 'my-custom-module',
+            'settings' => array(
+                'items' => array(
+                    array(
+                        'text' => 'my_text',
+                        '_id' => $field_id,
+                    ),
+                ),
+            ),
+        );
+
+        $node_id = 123;
+
+        $string = new WPML_PB_String( 'my_text', 'my-custom-module-text-123-1', 'title', 'LINE' );
+
+        $this->assertEquals( array( $string ), $subject->get( $node_id, $element_data ) );
+    }
+
 	/**
 	 * @test
 	 * @group wpmlcore-5803
@@ -532,6 +570,59 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 		$this->assertEquals( $expected_element_data, $subject->update( $node_id, $element_data, $string ) );
 	}
+
+    /**
+     * @test
+     */
+    public function it_updates_single_repeater_field_using_integration_class_instance() {
+        $subject = new WPML_Elementor_Translatable_Nodes();
+        $field_id = 1;
+
+        $nodes = array(
+            'my-custom-module'      => array(
+                'conditions'        => array( 'widgetType' => 'my-custom-module' ),
+                'fields'            => array(),
+                'integration-class' => new WPML_PB_My_Custom_Module_With_A_Single_Repeater_Field(),
+            ),
+        );
+
+        WP_Mock::onFilter( 'wpml_elementor_widgets_to_translate' )
+            ->with( WPML_Elementor_Translatable_Nodes::get_nodes_to_translate() )
+            ->reply( $nodes );
+
+        $element_data = array(
+            'widgetType' => 'my-custom-module',
+            'settings' => array(
+                'items' => array(
+                    array(
+                        'text' => 'my_text',
+                        '_id' => $field_id,
+                    ),
+                ),
+            ),
+        );
+
+        $node_id = 123;
+        $new_string_value = 'the_value';
+
+        $expected_element_data = array(
+            'widgetType' => 'my-custom-module',
+            'settings' => array(
+                'items' => array(
+                    array(
+                        'text' => $new_string_value,
+                        '_id' => $field_id,
+                        'index' => 0,
+                    ),
+                ),
+            ),
+        );
+
+        $string = new WPML_PB_String( 'my_text', 'my-custom-module-text-123-1', 'title', 'LINE' );
+        $string->set_value( $new_string_value );
+
+        $this->assertEquals( $expected_element_data, $subject->update( $node_id, $element_data, $string ) );
+    }
 
 	/**
 	 * @test

--- a/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
@@ -17,7 +17,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 	 * @param $fields
 	 */
 	public function it_gets( $type, $fields, $items_field, $items ) {
-		$node_id = rand_str( 10 );
+		$node_id  = rand_str( 10 );
 		$settings = array();
 
 		foreach ( $fields as $key => $field ) {
@@ -26,8 +26,8 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 			} else {
 				$settings[ $key ] = array(
 					$field['field'] => rand_str( 10 ),
-					'type' => $field['type'],
-					'editor_type' => $field['editor_type'],
+					'type'          => $field['type'],
+					'editor_type'   => $field['editor_type'],
 				);
 			}
 		}
@@ -43,13 +43,17 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 			}
 		}
 
-		$sub_items[ '_id' ] = mt_rand( 1, 10 );
+		$sub_items['_id'] = mt_rand( 1, 10 );
 		$settings[ $items_field ][] = $sub_items;
 
+		if ( 'heading' === $type ) {
+			$settings['header_size'] = 'h1';
+		}
+
 		$element = array(
-			'id' => $node_id,
+			'id'         => $node_id,
 			'widgetType' => $type,
-			'settings' => $settings,
+			'settings'   => $settings,
 		);
 
 		\WP_Mock::wpPassthruFunction( '__' );
@@ -82,9 +86,12 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 			if ( is_numeric( $key ) ) {
 				$string = $strings[ $key ];
 				$this->assertEquals( $element['settings'][ $field['field'] ], $string->get_value() );
-				$this->assertEquals( $field['field'] . '-' . $element[ 'widgetType'] . '-' . $node_id, $string->get_name() );
+				$this->assertEquals( $field['field'] . '-' . $element['widgetType'] . '-' . $node_id, $string->get_name() );
 				$this->assertEquals( $field['type'], $string->get_title() );
 				$this->assertEquals( $field['editor_type'], $string->get_editor_type() );
+				if ( 'heading' === $type ) {
+					$this->assertEquals( $element['settings']['header_size'], $string->get_wrap_tag() );
+				}
 			} else {
 				$string = $strings[0];
 				if ( 'button' === $type ) {
@@ -112,7 +119,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 				}
 
 				$this->assertEquals( $element['settings'][ $key ][ $field['field'] ], $string->get_value() );
-				$this->assertEquals( $field['field'] . '-' . $element[ 'widgetType'] . '-' . $node_id, $string->get_name() );
+				$this->assertEquals( $field['field'] . '-' . $element['widgetType'] . '-' . $node_id, $string->get_name() );
 				$this->assertEquals( $field['type'], $string->get_title() );
 				$this->assertEquals( $field['editor_type'], $string->get_editor_type() );
 			}
@@ -125,7 +132,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 				if ( is_numeric( $item_key ) ) {
 					$this->assertEquals( $element['settings'][ $items_field ][0][ $item['field'] ], $string->get_value() );
-					$this->assertEquals( $element['widgetType'] . '-' . $item['field'] . '-' . $node_id . '-' . $sub_items[ '_id' ], $string->get_name() );
+					$this->assertEquals( $element['widgetType'] . '-' . $item['field'] . '-' . $node_id . '-' . $sub_items['_id'], $string->get_name() );
 				} else {
 					$this->assertEquals( $element['settings'][ $items_field ][0][ $item_key ][ $item['field'] ], $string->get_value() );
 				}

--- a/tests/phpunit/tests/test-wpml-elementor-woocommerce-hooks.php
+++ b/tests/phpunit/tests/test-wpml-elementor-woocommerce-hooks.php
@@ -25,12 +25,27 @@ class Test_WPML_Elementor_WooCommerce_Hooks extends OTGS_TestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_not_change_if_post_type_is_NOT_in_query_vars() {
+		$subject = new WPML_Elementor_WooCommerce_Hooks();
+
+		$query = $this->get_wp_query();
+
+		$_POST['action'] = 'elementor_ajax';
+
+		$query->query_vars[ 'suppress_filters' ] = true;
+
+		$filtered_query = $subject->do_not_suppress_filters_on_product_widget( $query );
+
+		$this->assertTrue( $filtered_query->query_vars['suppress_filters'] );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_not_change_if_post_type_is_not_product() {
 		$subject = new WPML_Elementor_WooCommerce_Hooks();
 
-		$query = $this->getMockBuilder( 'WP_Query' )
-		              ->disableOriginalConstructor()
-		              ->getMock();
+		$query = $this->get_wp_query();
 
 		$_POST['action'] = 'elementor_ajax';
 
@@ -48,9 +63,7 @@ class Test_WPML_Elementor_WooCommerce_Hooks extends OTGS_TestCase {
 	public function it_should_not_change_if_action_global_is_not_set() {
 		$subject = new WPML_Elementor_WooCommerce_Hooks();
 
-		$query = $this->getMockBuilder( 'WP_Query' )
-			->disableOriginalConstructor()
-			->getMock();
+		$query = $this->get_wp_query();
 
 		$query->query_vars[ 'suppress_filters' ] = true;
 		$query->query_vars[ 'post_type' ] = 'product';
@@ -66,9 +79,7 @@ class Test_WPML_Elementor_WooCommerce_Hooks extends OTGS_TestCase {
 	public function it_should_not_change_if_action_global_is_different_than_the_one_for_adding_widgets() {
 		$subject = new WPML_Elementor_WooCommerce_Hooks();
 
-		$query = $this->getMockBuilder( 'WP_Query' )
-		              ->disableOriginalConstructor()
-		              ->getMock();
+		$query = $this->get_wp_query();
 
 		$query->query_vars[ 'suppress_filters' ] = true;
 		$query->query_vars[ 'post_type' ] = 'product';
@@ -86,9 +97,7 @@ class Test_WPML_Elementor_WooCommerce_Hooks extends OTGS_TestCase {
 	public function it_should_set_suppress_filters_to_false() {
 		$subject = new WPML_Elementor_WooCommerce_Hooks();
 
-		$query = $this->getMockBuilder( 'WP_Query' )
-		              ->disableOriginalConstructor()
-		              ->getMock();
+		$query = $this->get_wp_query();
 
 		$query->query_vars[ 'suppress_filters' ] = true;
 		$query->query_vars[ 'post_type' ] = 'product';
@@ -98,5 +107,14 @@ class Test_WPML_Elementor_WooCommerce_Hooks extends OTGS_TestCase {
 		$filtered_query = $subject->do_not_suppress_filters_on_product_widget( $query );
 
 		$this->assertFalse( $filtered_query->query_vars['suppress_filters'] );
+	}
+
+	/**
+	 * @return \WP_Query|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function get_wp_query() {
+		return $this->getMockBuilder( 'WP_Query' )
+					->disableOriginalConstructor()
+					->getMock();
 	}
 }


### PR DESCRIPTION
I created a reusable integration class for Elementor repeater fields where I need to add specifics by passing constructor params which is currently not possible. This addition makes it possible to pass an instance instead of a class string.