### PR TITLE
Language Switcher Widget for Elementor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,20 @@
       "email": "hello@wpml.org"
     }
   ],
+  "repositories": [
+    {
+      "type":"package",
+      "package": {
+        "name": "elementor/elementor",
+        "version":"master",
+        "source": {
+          "url": "https://github.com/elementor/elementor.git",
+          "type": "git",
+          "reference":"master"
+        }
+      }
+    }
+  ],
   "autoload": {
     "classmap": [
       "src/"
@@ -27,6 +41,12 @@
   "require-dev": {
     "phpunit/phpunit": "~5.7",
     "otgs/unit-tests-framework": "~1.2.0",
-    "wpml/page-builders": "dev-master"
+    "wpml/page-builders": "dev-master",
+    "elementor/elementor": "dev-master"
+  },
+  "scripts": {
+    "post-package-install": [
+      "sed -i 's/final public function add_group_control/public function add_group_control/g' ./vendor/elementor/elementor/includes/base/controls-stack.php"
+    ]
   }
 }

--- a/src/LanguageSwitcher/LanguageSwitcher.php
+++ b/src/LanguageSwitcher/LanguageSwitcher.php
@@ -8,17 +8,10 @@ class LanguageSwitcher implements \IWPML_Backend_Action, \IWPML_Frontend_Action 
 
 	public function add_hooks() {
 		add_action( 'elementor/widgets/widgets_registered', [ $this, 'registerWidgets' ] );
-		add_filter( 'wpml_custom_language_switcher_is_enabled', [ $this, 'enableCustomLanguageSwitcher' ] );
+		add_filter( 'wpml_custom_language_switcher_is_enabled', '__return_true' );
 	}
 
 	public function registerWidgets() {
 		Plugin::instance()->widgets_manager->register_widget_type( new Widget() );
-	}
-
-	/**
-	 * @return bool
-	 */
-	public function enableCustomLanguageSwitcher() {
-		return true;
 	}
 }

--- a/src/LanguageSwitcher/LanguageSwitcher.php
+++ b/src/LanguageSwitcher/LanguageSwitcher.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WPML\PB\Elementor\LanguageSwitcher;
+
+use Elementor\Plugin;
+
+class LanguageSwitcher implements \IWPML_Backend_Action, \IWPML_Frontend_Action {
+
+	public function add_hooks() {
+		add_action( 'elementor/widgets/widgets_registered', [ $this, 'registerWidgets' ] );
+	}
+
+	public function registerWidgets() {
+		Plugin::instance()->widgets_manager->register_widget_type( new Widget() );
+	}
+}

--- a/src/LanguageSwitcher/LanguageSwitcher.php
+++ b/src/LanguageSwitcher/LanguageSwitcher.php
@@ -8,9 +8,17 @@ class LanguageSwitcher implements \IWPML_Backend_Action, \IWPML_Frontend_Action 
 
 	public function add_hooks() {
 		add_action( 'elementor/widgets/widgets_registered', [ $this, 'registerWidgets' ] );
+		add_filter( 'wpml_custom_language_switcher_is_enabled', [ $this, 'enableCustomLanguageSwitcher' ] );
 	}
 
 	public function registerWidgets() {
 		Plugin::instance()->widgets_manager->register_widget_type( new Widget() );
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function enableCustomLanguageSwitcher() {
+		return true;
 	}
 }

--- a/src/LanguageSwitcher/Widget.php
+++ b/src/LanguageSwitcher/Widget.php
@@ -1,0 +1,61 @@
+<?php
+namespace WPML\PB\Elementor\LanguageSwitcher;
+
+use Elementor\Widget_Base;
+
+class Widget extends Widget_Base {
+
+	/** @var WidgetAdaptor $adaptor */
+	private $adaptor;
+
+	public function __construct( $data = [], $args = null, WidgetAdaptor $adaptor = null ) {
+		$this->adaptor = $adaptor ?: new WidgetAdaptor();
+		$this->adaptor->setTarget( $this );
+		parent::__construct( $data, $args );
+
+	}
+
+	/** @return string */
+	public function get_name() {
+		return $this->adaptor->getName();
+	}
+
+	/** @return string */
+	public function get_title() {
+		return $this->adaptor->getTitle();
+	}
+
+	/** @return string */
+	public function get_icon() {
+		return $this->adaptor->getIcon();
+	}
+
+	/** @return array */
+	public function get_categories() {
+		return $this->adaptor->getCategories();
+	}
+
+	/**
+	 * Register controls.
+	 *
+	 * Used to add new controls to any element type. For example, external
+	 * developers use this method to register controls in a widget.
+	 *
+	 * Should be inherited and register new controls using `add_control()`,
+	 * `add_responsive_control()` and `add_group_control()`, inside control
+	 * wrappers like `start_controls_section()`, `start_controls_tabs()` and
+	 * `start_controls_tab()`.
+	 */
+	protected function _register_controls() {
+		$this->adaptor->registerControls();
+	}
+
+	/**
+	 * Render element.
+	 *
+	 * Generates the final HTML on the frontend.
+	 */
+	protected function render() {
+		$this->adaptor->render();
+	}
+}

--- a/src/LanguageSwitcher/WidgetAdaptor.php
+++ b/src/LanguageSwitcher/WidgetAdaptor.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace WPML\PB\Elementor\LanguageSwitcher;
+
+use Elementor\Controls_Manager;
+use Elementor\Group_Control_Typography;
+use Elementor\Scheme_Color;
+
+class WidgetAdaptor {
+
+	/** @var Widget $widget */
+	private $widget;
+
+	public function setTarget( Widget $widget ) {
+		$this->widget = $widget;
+	}
+
+	/** @return string */
+	public function getName() {
+		return 'wpml-language-switcher';
+	}
+
+	/** @return string */
+	public function getTitle() {
+		return __( 'WPML Language Switcher', 'sitepress' );
+	}
+
+	/** @return string */
+	public function getIcon() {
+		return 'fa fa-globe';
+	}
+
+	/** @return array */
+	public function getCategories() {
+		return [ 'general' ];
+	}
+
+	/**
+	 * Register controls.
+	 *
+	 * Used to add new controls to any element type. For example, external
+	 * developers use this method to register controls in a widget.
+	 *
+	 * Should be inherited and register new controls using `add_control()`,
+	 * `add_responsive_control()` and `add_group_control()`, inside control
+	 * wrappers like `start_controls_section()`, `start_controls_tabs()` and
+	 * `start_controls_tab()`.
+	 */
+	public function registerControls() {
+		//Content Tab
+		$this->widget->start_controls_section(
+			'section_content',
+			[
+				'label' => __( 'Content', 'sitepress' ),
+				'type'  => Controls_Manager::SECTION,
+				'tab'   => Controls_Manager::TAB_CONTENT,
+			]
+		);
+
+		$this->widget->add_control(
+			'style',
+			[
+				'label'   => __('Language switcher type', 'sitepress'),
+				'type'    => Controls_Manager::SELECT,
+				'default' => 'custom',
+				'options' => [
+					'custom'            => __( 'Drop Down', 'sitepress' ), //wrong, it depends on settings in Languages -> Custom language switchers
+					'footer'            => __( 'Footer', 'sitepress' ),
+					'post_translations' => __( 'Post Translations', 'sitepress' ),
+				],
+			]
+		);
+
+		$this->widget->add_control(
+			'display_flag',
+			[
+				'label'        => __( 'Display Flag', 'sitepress' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'return_value' => 1,
+				'default'      => 1,
+			]
+		);
+
+		$this->widget->add_control(
+			'link_current',
+			[
+				'label'        => __( 'Show Active Language - has to be ON with Dropdown', 'sitepress' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'return_value' => 1,
+				'default'      => 1,
+			]
+		);
+
+		$this->widget->add_control(
+			'native_language_name',
+			[
+				'label'        => __( 'Native language name', 'sitepress' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'return_value' => 1,
+				'default'      => 1,
+			]
+		);
+
+		$this->widget->add_control(
+			'language_name_current_language',
+			[
+				'label'        => __( 'Language name in current language', 'sitepress' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'return_value' => 1,
+				'default'      => 1,
+			]
+		);
+
+		$this->widget->end_controls_section();
+
+		$this->widget->start_controls_section(
+			'style_section',
+			[
+				'label' => __( 'Style', 'sitepress' ),
+				'tab'   => Controls_Manager::TAB_STYLE,
+			]
+		);
+		$this->widget->start_controls_tabs( 'style_tabs' );
+
+		$this->widget->start_controls_tab(
+			'style_normal_tab',
+			[
+				'label' => __( 'Normal', 'sitepress' ),
+			]
+		);
+
+		$this->widget->add_group_control(
+			Group_Control_Typography::get_type(),
+			[
+				'name'     => 'switcher_typography',
+				'selector' => '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item',
+			]
+		);
+
+		$this->widget->add_control(
+			'switcher_text_color',
+			[
+				'label'     => __( 'Text Color', 'sitepress' ),
+				'type'      => Controls_Manager::COLOR,
+				'scheme'    => [
+					'type'  => Scheme_Color::get_type(),
+					'value' => Scheme_Color::COLOR_3,
+				],
+				'default'   => '',
+				'selectors' => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link, 
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a' => 'color: {{VALUE}}',
+				],
+			]
+		);
+
+		$this->widget->add_control(
+			'switcher_bg_color',
+			[
+				'label'     => __( 'Background Color', 'sitepress' ),
+				'type'      => Controls_Manager::COLOR,
+				'default'   => '',
+				'selectors' => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link, 
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a' => 'background-color: {{VALUE}}',
+				],
+			]
+		);
+
+		$this->widget->end_controls_tab();
+
+		$this->widget->start_controls_tab(
+			'style_hover_tab',
+			[
+				'label' => __( 'Hover', 'sitepress' ),
+			]
+		);
+		$this->widget->add_group_control(
+			Group_Control_Typography::get_type(),
+			[
+				'name'     => 'switcher_hover_typography',
+				'selector' => '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item:hover,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item.wpml-ls-item__active,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item.highlighted,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item:focus',
+			]
+		);
+
+		$this->widget->add_control(
+			'switcher_hover_color',
+			[
+				'label'     => __( 'Text Color', 'sitepress' ),
+				'type'      => Controls_Manager::COLOR,
+				'scheme'    => [
+					'type'  => Scheme_Color::get_type(),
+					'value' => Scheme_Color::COLOR_4,
+				],
+				'selectors' => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a:hover,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a:focus,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown .wpml-ls-current-language:hover>a,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link:hover,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link.wpml-ls-link__active,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link.highlighted,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link:focus' => 'color: {{VALUE}}',
+				],
+			]
+		);
+
+		$this->widget->end_controls_tab();
+
+		$this->widget->end_controls_tabs();
+
+		$this->widget->end_controls_section();
+
+		$this->widget->start_controls_section(
+			'language_flag',
+			[
+				'label'     => __( 'Language Flag', 'sitepress' ),
+				'tab'       => Controls_Manager::TAB_STYLE,
+				'condition' => [
+					'display_flag' => [ 1 ],
+				],
+			]
+		);
+
+		$this->widget->add_control(
+			'flag_margin',
+			[
+				'label'      => __( 'Margin', 'sitepress' ),
+				'type'       => Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%', 'em' ],
+				'selectors'  => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-flag' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+		$this->widget->end_controls_section();
+
+		$this->widget->start_controls_section(
+			'post_translation_text',
+			[
+				'label'     => __( 'Post Translation Text', 'sitepress' ),
+				'tab'       => Controls_Manager::TAB_STYLE,
+				'condition' => [
+					'style' => [ 'post_translations' ],
+				],
+			]
+		);
+
+		$this->widget->add_group_control(
+			Group_Control_Typography::get_type(),
+			[
+				'name' => 'post_translation_typography',
+				'selector' => '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations',
+			]
+		);
+
+		$this->widget->add_control(
+			'post_translation_color',
+			[
+				'label'     => __( 'Text Color', 'sitepress' ),
+				'type'      => Controls_Manager::COLOR,
+				'scheme'    => [
+					'type'  => Scheme_Color::get_type(),
+					'value' => Scheme_Color::COLOR_3,
+				],
+				'default'   => '',
+				'selectors' => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'color: {{VALUE}}',
+				],
+			]
+		);
+
+		$this->widget->add_control(
+			'post_translation_bg_color',
+			[
+				'label'     => __( 'Background Color', 'sitepress' ),
+				'type'      => Controls_Manager::COLOR,
+				'default'   => '',
+				'selectors' => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'background-color: {{VALUE}}',
+				],
+			]
+		);
+
+		$this->widget->add_control(
+			'post_translation_padding',
+			[
+				'label'      => __( 'Padding', 'sitepress' ),
+				'type'       => Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%', 'em' ],
+				'selectors'  => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+		$this->widget->add_control(
+			'post_translation_margin',
+			[
+				'label'      => __( 'Margin', 'sitepress' ),
+				'type'       => Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%', 'em' ],
+				'selectors'  => [
+					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+		$this->widget->end_controls_section();
+
+	}
+
+	/**
+	 * Render element.
+	 *
+	 * Generates the final HTML on the frontend.
+	 */
+	public function render() {
+		$settings = $this->widget->get_settings_for_display();
+
+		$this->widget->add_render_attribute('wpml-elementor-ls', 'class', [
+			'wpml-elementor-ls',
+		]);
+
+		$args = array(
+			'display_link_for_current_lang' => $settings['link_current'],
+			'flags'                         => $settings['display_flag'],
+			'native'                        => $settings['native_language_name'],
+			'translated'                    => $settings['language_name_current_language'],
+			'type'                          => $settings['style'],
+		);
+
+		if ( 'custom' === $settings['style'] ) {
+			//forcing in dropdown case
+			$args['display_link_for_current_lang'] = 1;
+		}
+
+		echo "<div " . $this->widget->get_render_attribute_string('wpml-elementor-ls') . ">";
+		do_action('wpml_language_switcher', $args);
+		echo "</div>";
+	}
+}

--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -20,7 +20,8 @@ class WPML_Elementor_Integration_Factory {
 				'WPML_Elementor_Adjust_Global_Widget_ID_Factory',
 				'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
 				'WPML_Elementor_Media_Hooks_Factory',
-				'WPML_Elementor_WooCommerce_Hooks_Factory'
+				'WPML_Elementor_WooCommerce_Hooks_Factory',
+				\WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
 			)
 		);
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -36,5 +36,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', realpath(WPML_ST_PATH . '/../../../') );
 }
 
+define( 'ELEMENTOR_PATH', __DIR__ . '/../../vendor/elementor/elementor/' );
+require_once ELEMENTOR_PATH . '/includes/autoloader.php';
+Elementor\Autoloader::run();
+// Load classes not included in Elementor's autoloader.
+require_once ELEMENTOR_PATH . '/core/base/base-object.php';
+require_once ELEMENTOR_PATH . '/includes/base/controls-stack.php';
+require_once ELEMENTOR_PATH . '/includes/base/element-base.php';
+require_once ELEMENTOR_PATH . '/includes/base/widget-base.php';
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';

--- a/tests/phpunit/stubs/IWPML_Backend_Action.php
+++ b/tests/phpunit/stubs/IWPML_Backend_Action.php
@@ -1,0 +1,3 @@
+<?php
+
+interface IWPML_Backend_Action {}

--- a/tests/phpunit/stubs/IWPML_Frontend_Action.php
+++ b/tests/phpunit/stubs/IWPML_Frontend_Action.php
@@ -1,0 +1,3 @@
+<?php
+
+interface IWPML_Frontend_Action {}

--- a/tests/phpunit/tests/LanguageSwitcher/TestWidget.php
+++ b/tests/phpunit/tests/LanguageSwitcher/TestWidget.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace WPML\PB\Elementor\LanguageSwitcher;
+
+/**
+ * @group language-switcher
+ */
+class TestWidget extends \OTGS_TestCase {
+
+	/**
+	 * @see \Elementor\Elements_Manager::create_element_instance
+	 *
+	 * @test
+	 */
+	public function itShouldBeInstantiatedWithSameArgumentsAsBaseClass() {
+		new Widget( [], [] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetName() {
+		$adaptor = $this->getAdaptor();
+		$adaptor->method( 'getName' )->willReturn( 'my name' );
+
+		$subject = $this->getSubject( $adaptor );
+
+		$this->assertEquals( 'my name', $subject->get_name() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetTitle() {
+		$adaptor = $this->getAdaptor();
+		$adaptor->method( 'getTitle' )->willReturn( 'my title' );
+
+		$subject = $this->getSubject( $adaptor );
+
+		$this->assertEquals( 'my title', $subject->get_title() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetIcon() {
+		$adaptor = $this->getAdaptor();
+		$adaptor->method( 'getIcon' )->willReturn( 'my icon' );
+
+		$subject = $this->getSubject( $adaptor );
+
+		$this->assertEquals( 'my icon', $subject->get_icon() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetCategories() {
+		$categories = [ 'my category' ];
+
+		$adaptor = $this->getAdaptor();
+		$adaptor->method( 'getCategories' )->willReturn( $categories );
+
+		$subject = $this->getSubject( $adaptor );
+
+		$this->assertEquals( $categories, $subject->get_categories() );
+	}
+
+	private function getSubject( $adaptor ) {
+		return new Widget( [], null, $adaptor );
+	}
+
+	private function getAdaptor() {
+		return $this->getMockBuilder( WidgetAdaptor::class )
+			->setMethods(
+				[
+					'getName',
+					'getTitle',
+					'getIcon',
+					'getCategories',
+				]
+			)->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
+++ b/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
@@ -1,0 +1,468 @@
+<?php
+
+namespace WPML\PB\Elementor\LanguageSwitcher;
+
+use Elementor\Controls_Manager;
+use Elementor\Group_Control_Typography;
+use Elementor\Scheme_Color;
+
+/**
+ * @group language-switcher
+ */
+class TestWidgetAdaptor extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldUsePublicMethodsFromWidget() {
+		$widgetReflection = new \ReflectionClass( Widget::class );
+
+		foreach ( $this->getPublicWidgetMethods() as $methodName ) {
+			$this->assertTrue( $widgetReflection->getMethod( $methodName )->isPublic() );
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetName() {
+		$subject = $this->getSubject();
+		$this->assertEquals( 'wpml-language-switcher', $subject->getName() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetTitle() {
+		$subject = $this->getSubject();
+		$this->assertEquals( 'WPML Language Switcher', $subject->getTitle() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetIcon() {
+		$subject = $this->getSubject();
+		$this->assertEquals( 'fa fa-globe', $subject->getIcon() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetCategories() {
+		$subject = $this->getSubject();
+		$this->assertEquals( [ 'general' ], $subject->getCategories() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldRegisterControls() {
+		$widget = $this->getWidget();
+
+		$this->setExpectedAddedSection( $widget );
+		$this->setExpectedAddedControl( $widget );
+		$this->setExpectedAddedTabs( $widget );
+		$this->setExpectedAddedGroupControls( $widget );
+
+		$subject = $this->getSubject( $widget );
+
+		$subject->registerControls();
+	}
+
+	/**
+	 * @param \PHPUnit_Framework_MockObject_MockObject $widget
+	 */
+	private function setExpectedAddedSection( $widget ) {
+		$sectionsNumber = 4;
+
+		$widget->expects( $this->exactly( $sectionsNumber ) )
+		       ->method( 'start_controls_section' )
+		       ->withConsecutive(
+			       [
+				       'section_content',
+				       [
+					       'label' => 'Content',
+					       'type'  => Controls_Manager::SECTION,
+					       'tab'   => Controls_Manager::TAB_CONTENT,
+				       ],
+			       ],
+			       [
+				       'style_section',
+				       [
+					       'label' => 'Style',
+					       'tab'   => Controls_Manager::TAB_STYLE,
+				       ]
+			       ],
+			       [
+				       'language_flag',
+				       [
+					       'label'     => 'Language Flag',
+					       'tab'       => Controls_Manager::TAB_STYLE,
+					       'condition' => [
+						       'display_flag' => [ 1 ],
+					       ],
+				       ]
+			       ],
+			       [
+				       'post_translation_text',
+				       [
+					       'label'     => 'Post Translation Text',
+					       'tab'       => Controls_Manager::TAB_STYLE,
+					       'condition' => [
+						       'style' => [ 'post_translations' ],
+					       ],
+				       ]
+			       ]
+		       );
+
+		$widget->expects( $this->exactly( $sectionsNumber ) )
+		       ->method( 'end_controls_section' );
+	}
+
+	/**
+	 * @param \PHPUnit_Framework_MockObject_MockObject $widget
+	 */
+	private function setExpectedAddedControl( $widget ) {
+		$widget->expects( $this->exactly( 13 ) )
+		       ->method( 'add_control' )
+		       ->withConsecutive(
+			       [
+				       'style',
+				       [
+					       'label'   => 'Language switcher type',
+					       'type'    => Controls_Manager::SELECT,
+					       'default' => 'custom',
+					       'options' => [
+						       'custom'            => 'Drop Down',
+						       'footer'            => 'Footer',
+						       'post_translations' => 'Post Translations',
+					       ],
+				       ]
+			       ],
+			       [
+				       'display_flag',
+				       [
+					       'label'        => 'Display Flag',
+					       'type'         => Controls_Manager::SWITCHER,
+					       'return_value' => 1,
+					       'default'      => 1,
+				       ],
+			       ],
+			       [
+				       'link_current',
+				       [
+					       'label'        => 'Show Active Language - has to be ON with Dropdown',
+					       'type'         => Controls_Manager::SWITCHER,
+					       'return_value' => 1,
+					       'default'      => 1,
+				       ],
+			       ],
+			       [
+				       'native_language_name',
+				       [
+					       'label'        => 'Native language name',
+					       'type'         => Controls_Manager::SWITCHER,
+					       'return_value' => 1,
+					       'default'      => 1,
+				       ],
+			       ],
+			       [
+				       'language_name_current_language',
+				       [
+					       'label'        => 'Language name in current language',
+					       'type'         => Controls_Manager::SWITCHER,
+					       'return_value' => 1,
+					       'default'      => 1,
+				       ],
+			       ],
+			       [
+				       'switcher_text_color',
+				       [
+					       'label'     => 'Text Color',
+					       'type'      => Controls_Manager::COLOR,
+					       'scheme'    => [
+						       'type'  => Scheme_Color::get_type(),
+						       'value' => Scheme_Color::COLOR_3,
+					       ],
+					       'default'   => '',
+					       'selectors' => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link, 
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a' => 'color: {{VALUE}}',
+					       ],
+				       ],
+			       ],
+			       [
+				       'switcher_bg_color',
+				       [
+					       'label'     => 'Background Color',
+					       'type'      => Controls_Manager::COLOR,
+					       'default'   => '',
+					       'selectors' => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link, 
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a' => 'background-color: {{VALUE}}',
+					       ],
+				       ],
+			       ],
+			       [
+				       'switcher_hover_color',
+				       [
+					       'label'     => 'Text Color',
+					       'type'      => Controls_Manager::COLOR,
+					       'scheme'    => [
+						       'type'  => Scheme_Color::get_type(),
+						       'value' => Scheme_Color::COLOR_4,
+					       ],
+					       'selectors' => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a:hover,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a:focus,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown .wpml-ls-current-language:hover>a,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link:hover,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link.wpml-ls-link__active,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link.highlighted,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item .wpml-ls-link:focus' => 'color: {{VALUE}}',
+					       ],
+				       ],
+			       ],
+			       [
+				       'flag_margin',
+				       [
+					       'label'      => 'Margin',
+					       'type'       => Controls_Manager::DIMENSIONS,
+					       'size_units' => [ 'px', '%', 'em' ],
+					       'selectors'  => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-flag' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+					       ],
+				       ],
+			       ],
+			       [
+				       'post_translation_color',
+				       [
+					       'label'     => 'Text Color',
+					       'type'      => Controls_Manager::COLOR,
+					       'scheme'    => [
+						       'type'  => Scheme_Color::get_type(),
+						       'value' => Scheme_Color::COLOR_3,
+					       ],
+					       'default'   => '',
+					       'selectors' => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'color: {{VALUE}}',
+					       ],
+				       ],
+			       ],
+			       [
+				       'post_translation_bg_color',
+				       [
+					       'label'     => 'Background Color',
+					       'type'      => Controls_Manager::COLOR,
+					       'default'   => '',
+					       'selectors' => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'background-color: {{VALUE}}',
+					       ],
+				       ],
+			       ],
+			       [
+				       'post_translation_padding',
+				       [
+					       'label'      => 'Padding',
+					       'type'       => Controls_Manager::DIMENSIONS,
+					       'size_units' => [ 'px', '%', 'em' ],
+					       'selectors'  => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+					       ],
+				       ],
+			       ],
+			       [
+				       'post_translation_margin',
+				       [
+					       'label'      => 'Margin',
+					       'type'       => Controls_Manager::DIMENSIONS,
+					       'size_units' => [ 'px', '%', 'em' ],
+					       'selectors'  => [
+						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+					       ],
+				       ],
+			       ]
+		       );
+	}
+
+	/**
+	 * @param \PHPUnit_Framework_MockObject_MockObject $widget
+	 */
+	private function setExpectedAddedTabs( $widget ) {
+		$tabsNumber = 2;
+
+		$widget->expects( $this->once() )
+		       ->method( 'start_controls_tabs' )
+		       ->with( 'style_tabs' );
+
+		$widget->expects( $this->once() )
+		       ->method( 'end_controls_tabs' );
+
+		$widget->expects( $this->exactly( $tabsNumber ) )
+		       ->method( 'start_controls_tab' )
+		       ->withConsecutive(
+			       [
+				       'style_normal_tab',
+				       [
+					       'label' => 'Normal'
+				       ],
+			       ],
+			       [
+				       'style_hover_tab',
+				       [
+					       'label' => 'Hover',
+				       ],
+			       ]
+		       );
+
+		$widget->expects( $this->exactly( $tabsNumber ) )
+		       ->method( 'end_controls_tab' );
+	}
+
+	/**
+	 * @param \PHPUnit_Framework_MockObject_MockObject $widget
+	 */
+	private function setExpectedAddedGroupControls( $widget ) {
+		$widget->expects( $this->exactly( 3 ) )
+		       ->method( 'add_group_control' )
+		       ->withConsecutive(
+					[
+						Group_Control_Typography::get_type(),
+						[
+						   'name'     => 'switcher_typography',
+						   'selector' => '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item',
+						],
+					],
+					[
+						Group_Control_Typography::get_type(),
+						[
+						   'name'     => 'switcher_hover_typography',
+						   'selector' => '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item:hover,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item.wpml-ls-item__active,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item.highlighted,
+					{{WRAPPER}} .wpml-elementor-ls .wpml-ls-item:focus',
+						],
+					],
+					[
+						Group_Control_Typography::get_type(),
+						[
+						   'name'     => 'post_translation_typography',
+						   'selector' => '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-statics-post_translations',
+						],
+					]
+		       );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpRender
+	 *
+	 * @param array $settings
+	 * @param array $expectedArgs
+	 */
+	public function itShouldRender( array $settings, array $expectedArgs ) {
+		$renderAttribute      = 'some-attribute';
+		$languageSwitcherHtml = 'The language switcher';
+
+		$widget = $this->getWidget();
+
+		$widget->method( 'get_settings_for_display' )
+			->willReturn( $settings );
+
+		$widget->expects( $this->once() )
+			->method( 'add_render_attribute' )
+			->with( 'wpml-elementor-ls', 'class', [ 'wpml-elementor-ls' ] );
+
+		\WP_Mock::onAction( 'wpml_language_switcher' )
+			->with( $expectedArgs )
+			->perform( function() use ( $languageSwitcherHtml ) {
+				echo $languageSwitcherHtml;
+			} );
+
+		$widget->method( 'get_render_attribute_string' )
+			->with( 'wpml-elementor-ls' )
+			->willReturn( $renderAttribute );
+
+		$subject = $this->getSubject( $widget );
+
+		ob_start();
+		$subject->render();
+		$output = ob_get_clean();
+
+		$this->assertEquals(
+			"<div $renderAttribute>$languageSwitcherHtml</div>",
+			$output
+		);
+	}
+
+	public function dpRender() {
+		return [
+			'style == custom' => [
+				[
+					'style'                          => 'custom',
+					'link_current'                   => 'param for link_current',
+					'display_flag'                   => 'param for display_flag',
+					'native_language_name'           => 'param for native_language_name',
+					'language_name_current_language' => 'param for language_name_current_language',
+				],
+				[
+					'display_link_for_current_lang' => 1,
+					'flags'                         => 'param for display_flag',
+					'native'                        => 'param for native_language_name',
+					'translated'                    => 'param for language_name_current_language',
+					'type'                          => 'custom',
+				]
+			],
+			'style != custom' => [
+				[
+					'style'                          => 'some-style',
+					'link_current'                   => 'param for link_current',
+					'display_flag'                   => 'param for display_flag',
+					'native_language_name'           => 'param for native_language_name',
+					'language_name_current_language' => 'param for language_name_current_language',
+				],
+				[
+					'display_link_for_current_lang' => 'param for link_current',
+					'flags'                         => 'param for display_flag',
+					'native'                        => 'param for native_language_name',
+					'translated'                    => 'param for language_name_current_language',
+					'type'                          => 'some-style',
+				]
+			],
+		];
+	}
+
+	private function getSubject( $widget = null ) {
+		$widget  = $widget ?: $this->getWidget();
+		$adaptor = new WidgetAdaptor();
+		$adaptor->setTarget( $widget );
+
+		return $adaptor;
+	}
+
+	/**
+	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getWidget() {
+		return $this->getMockBuilder( Widget::class )
+			->setMethods( $this->getPublicWidgetMethods() )
+			->disableOriginalConstructor()->getMock();
+	}
+
+	private function getPublicWidgetMethods() {
+		return [
+			'start_controls_section',
+			'add_control',
+			'end_controls_section',
+			'start_controls_tabs',
+			'start_controls_tab',
+			'add_group_control',
+			'end_controls_tab',
+			'end_controls_tabs',
+			'get_settings_for_display',
+			'add_render_attribute',
+			'get_render_attribute_string',
+		];
+	}
+}

--- a/tests/phpunit/tests/languageSwitcher/TestLanguageSwitcher.php
+++ b/tests/phpunit/tests/languageSwitcher/TestLanguageSwitcher.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WPML\PB\Elementor\LanguageSwitcher;
+
+/**
+ * @group language-switcher
+ */
+class TestLanguageSwitcher extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = new LanguageSwitcher();
+		\WP_Mock::expectActionAdded( 'elementor/widgets/widgets_registered', [ $subject, 'registerWidgets' ] );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldregisterWidgets() {
+		$subject = new LanguageSwitcher();
+
+		$widgetManager = $this->getMockBuilder( 'Elementor\Widgets_Manager' )
+		                      ->setMethods( [ 'register_widget_type' ] )
+			                  ->disableOriginalConstructor()
+		                      ->getMock();
+		$widgetManager->expects( $this->once() )->method( 'register_widget_type' )->with( new Widget() );
+
+		$elementorPlugin = \Mockery::mock( 'alias:Elementor\Plugin' );
+		$elementorPlugin->shouldReceive( 'instance' )->andReturnSelf();
+		$elementorPlugin->widgets_manager = $widgetManager;
+
+		$subject->registerWidgets();
+	}
+}

--- a/tests/phpunit/tests/languageSwitcher/TestLanguageSwitcher.php
+++ b/tests/phpunit/tests/languageSwitcher/TestLanguageSwitcher.php
@@ -13,7 +13,7 @@ class TestLanguageSwitcher extends \OTGS_TestCase {
 	public function itShouldAddHooks() {
 		$subject = new LanguageSwitcher();
 		\WP_Mock::expectActionAdded( 'elementor/widgets/widgets_registered', [ $subject, 'registerWidgets' ] );
-		\WP_Mock::expectFilterAdded( 'wpml_custom_language_switcher_is_enabled', [ $subject, 'enableCustomLanguageSwitcher' ] );
+		\WP_Mock::expectFilterAdded( 'wpml_custom_language_switcher_is_enabled', '__return_true' );
 		$subject->add_hooks();
 	}
 
@@ -34,15 +34,5 @@ class TestLanguageSwitcher extends \OTGS_TestCase {
 		$elementorPlugin->widgets_manager = $widgetManager;
 
 		$subject->registerWidgets();
-	}
-
-	/**
-	 * @test
-	 * @group wpmlcore-6669
-	 */
-	public function itShouldEnableCustomLanguageSwitcher() {
-		$subject = new LanguageSwitcher();
-
-		$this->assertTrue( $subject->enableCustomLanguageSwitcher() );
 	}
 }

--- a/tests/phpunit/tests/languageSwitcher/TestLanguageSwitcher.php
+++ b/tests/phpunit/tests/languageSwitcher/TestLanguageSwitcher.php
@@ -13,6 +13,7 @@ class TestLanguageSwitcher extends \OTGS_TestCase {
 	public function itShouldAddHooks() {
 		$subject = new LanguageSwitcher();
 		\WP_Mock::expectActionAdded( 'elementor/widgets/widgets_registered', [ $subject, 'registerWidgets' ] );
+		\WP_Mock::expectFilterAdded( 'wpml_custom_language_switcher_is_enabled', [ $subject, 'enableCustomLanguageSwitcher' ] );
 		$subject->add_hooks();
 	}
 
@@ -33,5 +34,15 @@ class TestLanguageSwitcher extends \OTGS_TestCase {
 		$elementorPlugin->widgets_manager = $widgetManager;
 
 		$subject->registerWidgets();
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6669
+	 */
+	public function itShouldEnableCustomLanguageSwitcher() {
+		$subject = new LanguageSwitcher();
+
+		$this->assertTrue( $subject->enableCustomLanguageSwitcher() );
 	}
 }

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -27,6 +27,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     'WPML_PB_Elementor_Handle_Custom_Fields_Factory',
 			                     'WPML_Elementor_Media_Hooks_Factory',
 			                     'WPML_Elementor_WooCommerce_Hooks_Factory',
+			                     \WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );


### PR DESCRIPTION
[I've been asked](https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6553) to create a language switcher widget for Elementor.
Thanks to @strategio's help, the widget is almost ready.

Note for me, more selectors still needed to cover various options in WPML->Languages -> custom language switchers