### PR TITLE
Translate popups

### DIFF
--- a/src/Hooks/DynamicElements.php
+++ b/src/Hooks/DynamicElements.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+class DynamicElements implements \IWPML_Frontend_Action, \IWPML_DIC_Action {
+
+	public function add_hooks() {
+		add_filter( 'elementor/frontend/builder_content_data', [ $this, 'convert' ] );
+	}
+
+	/**
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	public function convert( array $data ) {
+		foreach ( $data as &$item ) {
+			if ( $this->isDynamicLink( $item ) ) {
+					$item['settings']['__dynamic__']['link'] = $this->convertPopUpId( $item['settings']['__dynamic__']['link'] );
+			}
+
+			$item['elements'] = $this->convert( $item['elements'] );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @param array $data
+	 *
+	 * @return bool
+	 */
+	private function isDynamicLink( array $data ) {
+		return isset( $data['elType'] )
+		       && 'widget' === $data['elType']
+		       && isset( $data['settings']['__dynamic__']['link'] );
+	}
+
+	/**
+	 * @param string $tagString e.g. "[elementor-tag id="d3587f6" name="popup" settings="%7B%22popup%22%3A%228%22%7D"]"
+	 *
+	 * @return string
+	 */
+	private function convertPopUpId( $tagString ) {
+		preg_match( '/name="(.*?(?="))"/', $tagString, $tagNameMatch );
+
+		if ( ! $tagNameMatch || $tagNameMatch[1] !== 'popup' ) {
+			return $tagString;
+		}
+
+		return preg_replace_callback( '/settings="(.*?(?="]))/', function( array $matches ) {
+			$settings = json_decode( urldecode( $matches[1] ), true );
+
+			if ( ! isset( $settings['popup'] ) ) {
+				return $matches[0];
+			}
+
+			$settings['popup'] = $this->convertId( $settings['popup'] );
+			$replace           = urlencode( json_encode( $settings ) );
+
+			return str_replace( $matches[1], $replace, $matches[0] );
+
+		}, $tagString );
+	}
+
+	/**
+	 * @param int $elementId
+	 *
+	 * @return int
+	 */
+	private function convertId( $elementId ) {
+		return apply_filters( 'wpml_object_id', $elementId, get_post_type( $elementId ), true );
+	}
+}

--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -22,6 +22,7 @@ class WPML_Elementor_Integration_Factory {
 				'WPML_Elementor_Media_Hooks_Factory',
 				'WPML_Elementor_WooCommerce_Hooks_Factory',
 				\WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
+				\WPML\PB\Elementor\Hooks\DynamicElements::class,
 			)
 		);
 

--- a/tests/phpunit/stubs/IWPML_DIC_Action.php
+++ b/tests/phpunit/stubs/IWPML_DIC_Action.php
@@ -1,0 +1,3 @@
+<?php
+
+interface IWPML_DIC_Action {}

--- a/tests/phpunit/tests/Hooks/TestDynamicElements.php
+++ b/tests/phpunit/tests/Hooks/TestDynamicElements.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+/**
+ * @group hooks
+ * @group dynamic-element
+ * @group wpmlcore-6542
+ */
+class TestDynamicElements extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = new DynamicElements();
+		\WP_Mock::expectFilterAdded( 'elementor/frontend/builder_content_data', [ $subject, 'convert' ] );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNotConvertWithNoConvertibleBlock() {
+		$data = [
+			[
+				'elType'   => 'section',
+				'elements' => [],
+			],
+			[
+				'elType'   => 'widget',
+				'elements' => [],
+			],
+			[
+				'elType'   => 'widget',
+				'settings' => [
+					'__dynamic__' => [ 'not_a_link' ],
+				],
+				'elements' => [],
+			],
+			[
+				'elType'   => 'widget',
+				'settings' => [
+					'__dynamic__' => [
+						'link' => '[elementor-tag id="d3587f6"]',
+					],
+				],
+				'elements' => [],
+			],
+			[
+				'elType'   => 'widget',
+				'settings' => [
+					'__dynamic__' => [
+						'link' => '[elementor-tag id="d3587f6" settings="%7B%22popup%22%3A%228%22%7D"]',
+					],
+				],
+				'elements' => [],
+			],
+			[
+				'elType'   => 'widget',
+				'settings' => [
+					'__dynamic__' => [
+						'link' => '[elementor-tag id="d3587f6" name="not_a_popup" settings="%7B%22popup%22%3A%228%22%7D"]',
+					],
+				],
+				'elements' => [],
+			],
+			[
+				'elType'   => 'widget',
+				'settings' => [
+					'__dynamic__' => [
+						'link' => '[elementor-tag id="d3587f6" name="popup" settings="%7B%22not_a_popup%22%3A%228%22%7D"]',
+					],
+				],
+				'elements' => [],
+			],
+		];
+
+		$subject = new DynamicElements();
+
+		$filteredData = $subject->convert( $data );
+
+		$this->assertEquals( $data, $filteredData );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvert() {
+		$originalId  = 7;
+		$convertedId = 12;
+		$postType    = 'post_elementor_library';
+
+		\WP_Mock::userFunction( 'get_post_type', [
+			'args'   => [ $originalId ],
+			'return' => $postType,
+		] );
+
+		\WP_Mock::onFilter( 'wpml_object_id' )
+			->with( $originalId, $postType, true )
+			->reply( $convertedId );
+
+		$getData = function( $id ) {
+			$encodedSettings = urlencode( json_encode( [ 'popup' => $id ] ) );
+
+			return [
+				[
+					'elType'   => 'section',
+					'elements' => [],
+				],
+				[
+					'elType'   => 'section',
+					'elements' => [
+						[
+							'elType'   => 'section',
+							'elements' => [],
+						],
+						[
+							'elType'   => 'widget',
+							'settings' => [
+								'__dynamic__' => [
+									'link' => '[elementor-tag id="d3587f6" name="popup" settings="' . $encodedSettings . '"]',
+								],
+							],
+							'elements' => [],
+						],
+					],
+				],
+			];
+		};
+
+		$originalData = $getData( $originalId );
+		$expectedData = $getData( $convertedId );
+
+		$subject = new DynamicElements();
+
+		$this->assertEquals( $expectedData, $subject->convert( $originalData ) );
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -28,6 +28,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     'WPML_Elementor_Media_Hooks_Factory',
 			                     'WPML_Elementor_WooCommerce_Hooks_Factory',
 			                     \WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
+			                     \WPML\PB\Elementor\Hooks\DynamicElements::class,
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );


### PR DESCRIPTION
We will convert the popup ID on the fly as any other global element so
it does not depend on the order of the translations (the popup can be
translated after the page).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6542