### PR TITLE
Change the Language Switcher type string

### DIFF
--- a/src/LanguageSwitcher/WidgetAdaptor.php
+++ b/src/LanguageSwitcher/WidgetAdaptor.php
@@ -64,7 +64,7 @@ class WidgetAdaptor {
 				'type'    => Controls_Manager::SELECT,
 				'default' => 'custom',
 				'options' => [
-					'custom'            => __( 'Drop Down', 'sitepress' ), //wrong, it depends on settings in Languages -> Custom language switchers
+					'custom'            => __( 'Custom', 'sitepress' ),
 					'footer'            => __( 'Footer', 'sitepress' ),
 					'post_translations' => __( 'Post Translations', 'sitepress' ),
 				],

--- a/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
+++ b/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
@@ -134,7 +134,7 @@ class TestWidgetAdaptor extends \OTGS_TestCase {
 					       'type'    => Controls_Manager::SELECT,
 					       'default' => 'custom',
 					       'options' => [
-						       'custom'            => 'Drop Down',
+						       'custom'            => 'Custom',
 						       'footer'            => 'Footer',
 						       'post_translations' => 'Post Translations',
 					       ],


### PR DESCRIPTION
Change the string 'Drop Down' to 'Custom' in the Language Switcher widget

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6867