### PR TITLE
Support translation for dynamic content strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
       "email": "hello@wpml.org"
     }
   ],
-  "repositories": [
-    {
+  "repositories": {
+    "elementor": {
       "type":"package",
       "package": {
         "name": "elementor/elementor",
@@ -21,8 +21,12 @@
           "reference":"master"
         }
       }
+    },
+    "collect": {
+      "type": "vcs",
+      "url": "https://github.com/OnTheGoSystems/collect.git"
     }
-  ],
+  },
   "autoload": {
     "classmap": [
       "src/"
@@ -42,7 +46,8 @@
     "phpunit/phpunit": "~5.7",
     "otgs/unit-tests-framework": "~1.2.0",
     "wpml/page-builders": "dev-master",
-    "elementor/elementor": "dev-master"
+    "elementor/elementor": "dev-master",
+    "wpml/collect": "dev-wpml-collect-rename"
   },
   "scripts": {
     "post-install-cmd": [

--- a/src/DynamicContent/Strings.php
+++ b/src/DynamicContent/Strings.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace WPML\PB\Elementor\DynamicContent;
+
+use WPML\Collect\Support\Collection;
+use WPML_PB_String;
+
+class Strings {
+
+	const SETTINGS_REGEX        = '/settings="(.*?(?="]))/';
+	const NAME_PREFIX           = 'dynamic';
+	const DELIMITER             = '-';
+	const TRANSLATABLE_SETTINGS = [
+		'before',
+		'after',
+		'fallback',
+	];
+
+	/**
+	 * Remove the strings overwritten with dynamic content
+	 * and add the extra strings "before", "after" and "fallback".
+	 *
+	 * @param WPML_PB_String[] $strings
+	 * @param string            $nodeId
+	 * @param array             $element
+	 *
+	 * @return WPML_PB_String[]
+	 */
+	public static function filter( array $strings, $nodeId, array $element ) {
+
+		$dynamicFields = wpml_collect( isset( $element['settings']['__dynamic__'] ) ? $element['settings']['__dynamic__'] : [] );
+
+		$getStringKey = function ( WPML_PB_String $string ) {
+			return explode( '-', $string->get_name() )[0];
+		};
+
+		$updateFromDynamicFields = function( WPML_PB_String $string, $fieldKey ) use ( &$dynamicFields, $nodeId ) {
+			if ( $dynamicFields->has( $fieldKey ) ) {
+				return self::addBeforeAfterAndFallback( wpml_collect( [ $fieldKey => $dynamicFields->pull( $fieldKey ) ] ), $nodeId );
+			}
+
+			return $string;
+		};
+
+		return wpml_collect( $strings )
+			->keyBy( $getStringKey )
+			->map( $updateFromDynamicFields )
+			->merge( self::addBeforeAfterAndFallback( $dynamicFields, $nodeId ) )
+			->flatten()
+			->toArray();
+	}
+
+	private static function addBeforeAfterAndFallback( Collection $dynamicFields, $nodeId ) {
+		$dynamicFieldToSettingStrings = function( $dynamicTag, $tagKey ) use ( $nodeId ) {
+			preg_match( self::SETTINGS_REGEX, $dynamicTag, $matches );
+
+			$isTranslatableSetting = function( $value, $settingField ) {
+				return in_array( $settingField, self::TRANSLATABLE_SETTINGS );
+			};
+
+			$buildStringFromSetting = function( $value, $settingField ) use ( $nodeId, $tagKey ) {
+				return new WPML_PB_String(
+					$value,
+					self::getStringName( $nodeId, $tagKey, $settingField ),
+					sprintf( __( 'Dynamic content string: %s', 'sitepress' ), $tagKey ),
+					'LINE'
+				);
+			};
+
+			return wpml_collect( isset( $matches[1] ) ? self::decodeSettings( $matches[1] ) : [] )
+				->filter( $isTranslatableSetting )
+				->map( $buildStringFromSetting );
+		};
+		
+		return $dynamicFields->map( $dynamicFieldToSettingStrings );
+	}
+
+	/**
+	 * @param array          $element
+	 * @param WPML_PB_String $string
+	 *
+	 * @return array
+	 */
+	public static function updateNode( array $element, WPML_PB_String $string ) {
+		$stringNameParts = explode( self::DELIMITER, $string->get_name() );
+
+		if ( count( $stringNameParts ) !== 4 || self::NAME_PREFIX !== $stringNameParts[0] ) {
+			return $element;
+		}
+
+		list( , , $dynamicField, $settingField ) = $stringNameParts;
+
+		if ( ! isset( $element['settings']['__dynamic__'][ $dynamicField ] ) ) {
+			return $element;
+		}
+
+		$replaceSettingStrings = function( array $matches ) use ( $string, $settingField ) {
+			$settings                  = self::decodeSettings( $matches[1] );
+			$settings[ $settingField ] = $string->get_value();
+			$replace                   = urlencode( json_encode( $settings ) );
+
+			return str_replace( $matches[1], $replace, $matches[0] );
+
+		};
+
+		$element['settings']['__dynamic__'][ $dynamicField ] = preg_replace_callback(
+			self::SETTINGS_REGEX,
+			$replaceSettingStrings,
+			$element['settings']['__dynamic__'][ $dynamicField ]
+		);
+
+		return $element;
+	}
+
+	/**
+	 * @param string $settingsString
+	 *
+	 * @return array
+	 */
+	private static function decodeSettings( $settingsString ) {
+		return json_decode( urldecode( $settingsString ), true );
+	}
+
+	/**
+	 * @param string $nodeId
+	 * @param string $tagKey
+	 * @param string $settingField
+	 *
+	 * @return string
+	 */
+	public static function getStringName( $nodeId, $tagKey, $settingField ) {
+		return self::NAME_PREFIX . self::DELIMITER. $nodeId . self::DELIMITER . $tagKey . self::DELIMITER . $settingField;
+	}
+}

--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPML\PB\Elementor\DynamicContent\Strings as DynamicContentStrings;
+
 /**
  * Class WPML_Elementor_Translatable_Nodes
  */
@@ -67,7 +69,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 			}
 		}
 
-		return $strings;
+		return DynamicContentStrings::filter( $strings, $node_id, $element );
 	}
 
 	/**
@@ -117,7 +119,7 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 			}
 		}
 
-		return $element;
+		return DynamicContentStrings::updateNode( $element, $string );
 	}
 
 	/**

--- a/tests/phpunit/tests/DynamicContent/TestStrings.php
+++ b/tests/phpunit/tests/DynamicContent/TestStrings.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace WPML\PB\Elementor\DynamicContent;
+
+use WPML_PB_String;
+
+/**
+ * @group dynamic-content
+ * @group wpmlcore-6244
+ */
+class TestStrings extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dpElementWithoutDynamicContent
+	 *
+	 * @param array $elementWithoutDynamicContent
+	 */
+	public function itShouldNotFilterIfElementDoesNotHaveDynamicContent( array $elementWithoutDynamicContent ) {
+		$strings = [
+			new WPML_PB_String( 'the value', 'the name', 'the title', 'LINE' ),
+		];
+
+		$nodeId = 'ef89gl32';
+
+		$this->assertSame( $strings, Strings::filter( $strings, $nodeId, $elementWithoutDynamicContent ) );
+	}
+
+	public function dpElementWithoutDynamicContent() {
+		return [
+			[ [] ],
+			[ [ 'settings' => [ 'text' => [] ] ] ],
+		];
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddDynamicContentStringsAndRemoveStaticOnes() {
+		$fieldName1         = 'title';
+		$fieldName2         = 'content';
+		$staticStringValue1 = 'the static text 1';
+		$staticStringValue2 = 'the static text 2';
+		$before             = 'my before';
+		$after              = 'my after';
+		$fallback           = 'my fallback';
+		$before2            = 'my before 2';
+
+		$nodeId = 'ef89gl32';
+
+		$settings1 = [
+			'before'   => $before,
+			'after'    => $after,
+			'fallback' => $fallback,
+			'foo'      => 'bar', // Filter out because not in the translatable whitelist
+		];
+
+		$settings2 = [
+			'before' => $before2,
+		];
+
+		$element = [
+			'settings' => [
+				$fieldName1 => $staticStringValue1,
+				'foo1'      => 'bar1',
+				'foo2'      => 'bar2',
+				$fieldName2 => $staticStringValue2, // This field is not translatable (no static string) but has dynamic settings.
+				'__dynamic__' => [
+					$fieldName1   => '[elementor-tag id="cc0b6c6" name="post-title" settings="' . urlencode( json_encode( $settings1 ) ) . '"]',
+					$fieldName2 => '[elementor-tag id="gf45gg9" name="post-content" settings="' . urlencode( json_encode( $settings2 ) ) . '"]',
+				],
+			]
+		];
+
+		$pbStringTitle = new WPML_PB_String( $staticStringValue1, self::getStaticStringName( $fieldName1 ), 'the title', 'LINE' );
+		$pbStringFoo1  = new WPML_PB_String( 'bar1', self::getStaticStringName( 'foo1' ), 'the foo1', 'LINE' );
+		$pbStringFoo2  = new WPML_PB_String( 'bar2', self::getStaticStringName( 'foo2' ), 'the foo2', 'LINE' );
+
+		$originalStrings = [
+			$pbStringFoo1,
+			$pbStringTitle,
+			$pbStringFoo2,
+		];
+
+		$expectedStrings = [
+			$pbStringFoo1,
+			self::getPbString( $before, $nodeId, $fieldName1, 'before' ),
+			self::getPbString( $after, $nodeId, $fieldName1, 'after' ),
+			self::getPbString( $fallback, $nodeId, $fieldName1, 'fallback' ),
+			$pbStringFoo2,
+			self::getPbString( $before2, $nodeId, $fieldName2, 'before' ),
+		];
+
+		$this->assertEquals( $expectedStrings, Strings::filter( $originalStrings, $nodeId, $element ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpNotDynamicStringName
+	 *
+	 * @param string $stringName
+	 */
+	public function itShouldNotUpdateNodeIfNotDynamicContentString( $stringName ) {
+		$before   = 'my before';
+		$after    = 'my after';
+		$fallback = 'my fallback';
+
+		$settings = [
+			'before'   => $before,
+			'after'    => $after,
+			'fallback' => $fallback,
+		];
+
+		$element = [
+			'settings' => [
+				'title' => 'the static title',
+				'__dynamic__' => [
+					'title' => '[elementor-tag id="cc0b6c6" name="post-title" settings="' . urlencode( json_encode( $settings ) ) . '"]'
+				],
+			]
+		];
+
+		$pbString = new WPML_PB_String( 'some value', $stringName, 'some title', 'LINE' );
+
+		$this->assertSame( $element, Strings::updateNode( $element, $pbString ) );
+	}
+
+	public function dpNotDynamicStringName() {
+		return [
+			'no delimiter'             => [ 'string without any delimiter' ],
+			'less than 4 parts'        => [ Strings::NAME_PREFIX . '-3-parts' ],
+			'more than 4 parts'        => [ Strings::NAME_PREFIX . '-name-with-more-than-4-parts' ],
+			'not starting with prefix' => [ 'non-' . Strings::NAME_PREFIX . '-string-name' ],
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpElementWithoutDynamicContent
+	 *
+	 * @param array $elementWithoutDynamicContent
+	 */
+	public function itShouldNotUpdateNodeIfNoDynamicContentField( array $elementWithoutDynamicContent ) {
+		$validDynamicContentPbString = self::getPbString( 'some value', '45gh69ee', 'title', 'before');
+
+		$this->assertSame(
+			$elementWithoutDynamicContent,
+			Strings::updateNode( $elementWithoutDynamicContent, $validDynamicContentPbString )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldUpdateNodeWithDynamicContentString() {
+		$originalBefore   = 'my before';
+		$translatedBefore = 'TRANSLATED my before';
+		$fieldName        = 'title';
+
+		$string = self::getPbString( $translatedBefore, '45gh69ee', $fieldName, 'before');
+
+		$getElement = function( $beforeText ) use ( $fieldName ) {
+			$settings = [
+				'before'   => $beforeText,
+				'after'    => 'my after',
+				'fallback' => 'my fallback',
+			];
+
+			return [
+				'settings' => [
+					$fieldName => 'the static title',
+					'__dynamic__' => [
+						$fieldName => '[elementor-tag id="cc0b6c6" name="post-title" settings="' . urlencode( json_encode( $settings ) ) . '"]'
+					],
+				]
+			];
+		};
+
+		$originalElement = $getElement( $originalBefore );
+		$expectedElement = $getElement( $translatedBefore );
+
+		$this->assertSame(
+			$expectedElement,
+			Strings::updateNode( $originalElement, $string )
+		);
+	}
+
+	/**
+	 * @see \WPML_Elementor_Translatable_Nodes::get_string_name()
+	 *
+	 * @param string $nodeId
+	 * @param string $fieldName
+	 * @param string $widgetType
+	 *
+	 * @return string
+	 */
+	private static function getStaticStringName( $fieldName ) {
+		return $fieldName . '-someWidgetType-someNodId';
+	}
+
+	/**
+	 * @param string $value
+	 * @param string $nodeId
+	 * @param string $fieldName
+	 * @param string $settingName
+	 *
+	 * @return WPML_PB_String
+	 */
+	private static function getPbString( $value, $nodeId, $fieldName, $settingName ) {
+		return new WPML_PB_String( $value, Strings::getStringName( $nodeId, $fieldName, $settingName ), "Dynamic content string: $fieldName", 'LINE' );
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
@@ -1,5 +1,8 @@
 <?php
 
+use tad\FunctionMocker\FunctionMocker;
+use WPML\PB\Elementor\DynamicContent\Strings as DynamicContentStrings;
+
 /**
  * Class Test_WPML_Translatable_Nodes
  *
@@ -11,6 +14,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6244
 	 * @dataProvider node_data_provider
 	 *
 	 * @param $type
@@ -58,6 +62,10 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 		\WP_Mock::wpPassthruFunction( '__' );
 		\WP_Mock::wpPassthruFunction( 'esc_html__' );
+
+		$dynamicContentStrings = FunctionMocker::replace( DynamicContentStrings::class . '::filter', function( $strings ) {
+			return $strings;
+		} );
 
 		$subject = new WPML_Elementor_Translatable_Nodes();
 		$strings = $subject->get( $node_id, $element );
@@ -153,6 +161,8 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 				$key++;
 			}
 		}
+
+		$dynamicContentStrings->wasCalledWithOnce( [ $strings, $node_id, FunctionMocker::isType( 'array' ) ] );
 	}
 
 	public function node_data_provider() {
@@ -478,6 +488,7 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 	/**
 	 * @test
 	 * @group wpmlcore-6436
+	 * @group wpmlcore-6244
 	 */
 	public function it_gets_nodes_regardless_of_their_array_key_in_their_definition() {
 		$widget_type  = 'wpmlcore-6436';
@@ -514,11 +525,17 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 		$string_name     = $field . '-' . $widget_type . '-' . $node_id;
 		$expected_string = new WPML_PB_String( $string_value, $string_name, $title, $editor_type );
 
+		$dynamicContentStrings = FunctionMocker::replace( DynamicContentStrings::class . '::filter', function( $strings ) {
+			return $strings;
+		} );
+
 		$subject = new WPML_Elementor_Translatable_Nodes();
 		$strings = $element = $subject->get( $node_id, $element );
 
 		$this->assertCount( 1, $strings );
 		$this->assertEquals( $expected_string, $strings[0] );
+
+		$dynamicContentStrings->wasCalledWithOnce( [ $strings, $node_id, FunctionMocker::isType( 'array' ) ] );
 	}
 
 	/**
@@ -538,10 +555,16 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 		$string = new WPML_PB_String( $translation, 'editor-text-editor-' . $node_id, 'anything', 'anything' );
 
+		$dynamicContentStrings = FunctionMocker::replace( DynamicContentStrings::class . '::updateNode', function( $element) {
+			return $element;
+		} );
+
 		$subject = new WPML_Elementor_Translatable_Nodes();
 		$element = $subject->update( $node_id, $element, $string );
 
 		$this->assertEquals( $translation, $element['settings']['editor'] );
+
+		$dynamicContentStrings->wasCalledWithOnce( [ $element, $string ] );
 	}
 
 	/**
@@ -620,6 +643,10 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 		$node_id = 123;
 
+		FunctionMocker::replace( DynamicContentStrings::class . '::filter', function( $strings ) {
+			return $strings;
+		} );
+
 		$string = new WPML_PB_String( 'my_text', 'my-custom-module-text-123-1', 'title', 'LINE' );
 
 		$this->assertEquals( array( $string ), $subject->get( $node_id, $element_data ) );
@@ -657,6 +684,10 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
         );
 
         $node_id = 123;
+
+	    FunctionMocker::replace( DynamicContentStrings::class . '::filter', function( $strings ) {
+		    return $strings;
+	    } );
 
         $string = new WPML_PB_String( 'my_text', 'my-custom-module-text-123-1', 'title', 'LINE' );
 
@@ -702,6 +733,10 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 		);
 
 		$node_id = 123;
+
+		FunctionMocker::replace( DynamicContentStrings::class . '::filter', function( $strings ) {
+			return $strings;
+		} );
 
 		$string = new WPML_PB_String( 'my_text', 'my-custom-module-text-123-1', 'title', 'LINE' );
 		$string2 = new WPML_PB_String( 'my_text_2', 'my-custom-module-text-123-1', 'title', 'LINE' );
@@ -753,6 +788,10 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 		);
 
 		$node_id = 123;
+
+		FunctionMocker::replace( DynamicContentStrings::class . '::filter', function( $strings ) {
+			return $strings;
+		} );
 
 		$string_1 = new WPML_PB_String( 'http://first-url.com', 'example_url_1-custom-module-123', 'Example URL 1', 'LINE' );
 		$string_2 = new WPML_PB_String( 'http://second-url.com', 'example_url_2-custom-module-123', 'Example URL 2', 'LINE' );


### PR DESCRIPTION
When a user selects a "dynamic source" for the content of an element, he
can also set 3 extra strings: "before", "after", "fallback".

These 3 strings will now be translatable.

Note: Dynamic content can be used for any kind of node (AFAICS) so it should apply to all nodes, even the ones that are not translatable.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6244