### PR TITLE
Fix failing tests in Elementor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "wpml/collect": "dev-wpml-collect-rename"
   },
   "scripts": {
-    "post-install-cmd": [
+    "post-update-cmd": [
       "sed -i 's/final public function add_group_control/public function add_group_control/g' ./vendor/elementor/elementor/includes/base/controls-stack.php"
     ]
   }

--- a/src/LanguageSwitcher/WidgetAdaptor.php
+++ b/src/LanguageSwitcher/WidgetAdaptor.php
@@ -4,7 +4,7 @@ namespace WPML\PB\Elementor\LanguageSwitcher;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Schemes\Color as SchemeColor;
 
 class WidgetAdaptor {
 
@@ -143,8 +143,8 @@ class WidgetAdaptor {
 				'label'     => __( 'Text Color', 'sitepress' ),
 				'type'      => Controls_Manager::COLOR,
 				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+					'type'  => SchemeColor::get_type(),
+					'value' => SchemeColor::COLOR_3,
 				],
 				'default'   => '',
 				'selectors' => [
@@ -192,8 +192,8 @@ class WidgetAdaptor {
 				'label'     => __( 'Text Color', 'sitepress' ),
 				'type'      => Controls_Manager::COLOR,
 				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_4,
+					'type'  => SchemeColor::get_type(),
+					'value' => SchemeColor::COLOR_4,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a:hover,
@@ -263,8 +263,8 @@ class WidgetAdaptor {
 				'label'     => __( 'Text Color', 'sitepress' ),
 				'type'      => Controls_Manager::COLOR,
 				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+					'type'  => SchemeColor::get_type(),
+					'value' => SchemeColor::COLOR_3,
 				],
 				'default'   => '',
 				'selectors' => [

--- a/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
+++ b/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
@@ -4,7 +4,7 @@ namespace WPML\PB\Elementor\LanguageSwitcher;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Schemes\Color as SchemeColor;
 
 /**
  * @group language-switcher
@@ -182,8 +182,8 @@ class TestWidgetAdaptor extends \OTGS_TestCase {
 					       'label'     => 'Text Color',
 					       'type'      => Controls_Manager::COLOR,
 					       'scheme'    => [
-						       'type'  => Scheme_Color::get_type(),
-						       'value' => Scheme_Color::COLOR_3,
+						       'type'  => SchemeColor::get_type(),
+						       'value' => SchemeColor::COLOR_3,
 					       ],
 					       'default'   => '',
 					       'selectors' => [
@@ -210,8 +210,8 @@ class TestWidgetAdaptor extends \OTGS_TestCase {
 					       'label'     => 'Text Color',
 					       'type'      => Controls_Manager::COLOR,
 					       'scheme'    => [
-						       'type'  => Scheme_Color::get_type(),
-						       'value' => Scheme_Color::COLOR_4,
+						       'type'  => SchemeColor::get_type(),
+						       'value' => SchemeColor::COLOR_4,
 					       ],
 					       'selectors' => [
 						       '{{WRAPPER}} .wpml-elementor-ls .wpml-ls-legacy-dropdown a:hover,
@@ -241,8 +241,8 @@ class TestWidgetAdaptor extends \OTGS_TestCase {
 					       'label'     => 'Text Color',
 					       'type'      => Controls_Manager::COLOR,
 					       'scheme'    => [
-						       'type'  => Scheme_Color::get_type(),
-						       'value' => Scheme_Color::COLOR_3,
+						       'type'  => SchemeColor::get_type(),
+						       'value' => SchemeColor::COLOR_3,
 					       ],
 					       'default'   => '',
 					       'selectors' => [

--- a/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-elementor-media-node-image.php
@@ -56,6 +56,8 @@ class Test_WPML_Elementor_Media_Node_Image extends OTGS_TestCase {
 			'caption' => '',
 		);
 
+		\WP_Mock::userFunction( 'wp_prepare_attachment_for_js' )->andReturn( $settings );
+
 		$media_translate = $this->get_media_translate();
 
 		$subject = $this->get_subject( $media_translate );

--- a/tests/phpunit/tests/test-wpml-elementor-register-strings.php
+++ b/tests/phpunit/tests/test-wpml-elementor-register-strings.php
@@ -78,6 +78,8 @@ class Test_WPML_Elementor_Register_Strings extends WPML_PB_TestCase2 {
 		              ->with( array( json_encode( $elementor_data ) ) )
 		              ->willReturn( json_decode( json_encode( $elementor_data ), true ) );
 
+		$data_settings->method( 'is_handling_post' )->with( $post->ID )->willReturn( true );
+
 		$string_registration = $this->getMockBuilder( 'WPML_PB_String_Registration' )
 			->setMethods( array( 'register_string' ) )
 			->disableOriginalConstructor()


### PR DESCRIPTION
We had several problems and I kept every fix in a separate commit.

**FTR: We are loading Elementor plugin (free version) as a composer dependency because we use some constants from there.**

The commit that is affecting the code base is [Update deprecated classname `Scheme_Color` to `Core\Schemes\Color`](https://github.com/OnTheGoSystems/wpml-page-builders-elementor/commit/3cd3250924197c390d3c004926b81144235e048b). The old class has been deprecated in Elementor `2.8.0` (released on 2019-12-09).

This failing test was caught because `ELEMENTOR_VERSION` constant is not defined in the tests and it triggered an error in `Elementor\Utils::handle_deprecation` (which is a good catch for us).

I tested `master` and this branch against Elementor `2.9.7` (current latest version) and I could not see any issue (the old class is an alias of the new one in Elementor's autoloader).