### PR TITLE
Fix a fatal error when a module with items has strings instead of an array

### DIFF
--- a/src/DynamicContent/Strings.php
+++ b/src/DynamicContent/Strings.php
@@ -79,7 +79,7 @@ class Strings {
 	 * @return Collection
 	 */
 	private static function getDynamicFieldsForModuleWithItems( array $element ) {
-		$isDynamic = function( array $item ) { return isset( $item[ self::KEY_DYNAMIC ] ); };
+		$isDynamic = function( $item ) { return isset( $item[ self::KEY_DYNAMIC ] ); };
 		$getFields = function( array $item ) use ( $element ) {
 			return self::getFields(
 				$item[ self::KEY_DYNAMIC ],


### PR DESCRIPTION
I don't know yet how to reproduce this, I believe it's because of a specific data shape. But I think removing the type hint is safe because this function will just check if it's an array with a specific element after.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7255