### PR TITLE
Support Form Steps in Elementor Pro 2.10.0

### DIFF
--- a/src/modules/class-wpml-elementor-form.php
+++ b/src/modules/class-wpml-elementor-form.php
@@ -16,7 +16,17 @@ class WPML_Elementor_Form extends WPML_Elementor_Module_With_Items {
 	 * @return array
 	 */
 	public function get_fields() {
-		return array( 'field_label', 'placeholder', 'field_html', 'acceptance_text', 'field_options' );
+		return [
+			'field_label',
+			'placeholder',
+			'field_html',
+			'acceptance_text',
+			'field_options',
+			'step_next_label',
+			'step_previous_label',
+			'previous_button',
+			'next_button',
+		];
 	}
 
 	/**
@@ -25,25 +35,17 @@ class WPML_Elementor_Form extends WPML_Elementor_Module_With_Items {
 	 * @return string
 	 */
 	protected function get_title( $field ) {
-		switch( $field ) {
-			case 'field_label':
-				return esc_html__( 'Form: Field label', 'sitepress' );
-
-			case 'placeholder':
-				return esc_html__( 'Form: Field placeholder', 'sitepress' );
-
-			case 'field_html':
-				return esc_html__( 'Form: Field HTML', 'sitepress' );
-				
-            case 'acceptance_text':
-                return esc_html__( 'Form: Acceptance Text', 'sitepress' );
-
-            case 'field_options':
-                return esc_html__( 'Form: Checkbox Options', 'sitepress' );
-				
-			default:
-				return '';
-		}
+		return wpml_collect( [
+			'field_label'            => esc_html__( 'Form: Field label', 'sitepress' ),
+			'placeholder'            => esc_html__( 'Form: Field placeholder', 'sitepress' ),
+			'field_html'             => esc_html__( 'Form: Field HTML', 'sitepress' ),
+			'acceptance_text'        => esc_html__( 'Form: Acceptance Text', 'sitepress' ),
+			'field_options'          => esc_html__( 'Form: Checkbox Options', 'sitepress' ),
+			'step_next_label'        => esc_html__( 'Form: Step Next Label', 'sitepress' ),
+			'step_previous_label'    => esc_html__( 'Form: Step Previous Label', 'sitepress' ),
+			'previous_button'        => esc_html__( 'Form: Previous Button', 'sitepress' ),
+			'next_button'            => esc_html__( 'Form: Next Button', 'sitepress' ),
+		] )->get( $field, '' );
 	}
 
 	/**
@@ -52,21 +54,16 @@ class WPML_Elementor_Form extends WPML_Elementor_Module_With_Items {
 	 * @return string
 	 */
 	protected function get_editor_type( $field ) {
-		switch( $field ) {
-			case 'field_label':
-			case 'placeholder':
-            case 'acceptance_text':			
-				return 'LINE';
-
-			case 'field_html':
-				return 'VISUAL';	
-				
-            case 'field_options':
-                return 'AREA';				
-
-			default:
-				return '';
-		}
+		return wpml_collect( [
+			'field_label'            => 'LINE',
+			'placeholder'            => 'LINE',
+			'field_html'             => 'VISUAL',
+			'acceptance_text'        => 'LINE',
+			'field_options'          => 'AREA',
+			'step_next_label'        => 'LINE',
+			'step_previous_label'    => 'LINE',
+			'previous_button'        => 'LINE',
+			'next_button'            => 'LINE',
+		] )->get( $field, '' );
 	}
-
 }

--- a/src/modules/class-wpml-elementor-module-with-items.php
+++ b/src/modules/class-wpml-elementor-module-with-items.php
@@ -80,6 +80,11 @@ abstract class WPML_Elementor_Module_With_Items implements IWPML_Page_Builders_M
 		foreach ( $this->get_items( $element ) as $key => $item ) {
 			foreach( $this->get_fields() as $field_key => $field ) {
 				if ( ! is_array( $field ) ) {
+
+					if ( ! isset( $item[ $field ] ) ) {
+						continue;
+					}
+
 					if ( $this->get_string_name( $node_id, $item[ $field ], $field, $element['widgetType'], $item['_id'] ) === $string->get_name() ) {
 						$item[ $field ] = $string->get_value();
 						$item['index'] = $key;
@@ -87,6 +92,10 @@ abstract class WPML_Elementor_Module_With_Items implements IWPML_Page_Builders_M
 					}
 				} else {
 					foreach ( $field as $inner_field ) {
+						if ( ! isset( $item[ $field_key ][ $inner_field ] ) ) {
+							continue;
+						}
+
 						if ( $this->get_string_name( $node_id, $item[ $field_key ][ $inner_field ], $inner_field, $element['widgetType'], $item['_id'] ) === $string->get_name() ) {
 							$item[ $field_key ][ $inner_field ] = $string->get_value();
 							$item['index'] = $key;

--- a/tests/phpunit/tests/modules/Test_WPML_Elementor_Module_With_Items.php
+++ b/tests/phpunit/tests/modules/Test_WPML_Elementor_Module_With_Items.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * @group module-with-items
+ */
+class Test_WPML_Elementor_Module_With_Items extends OTGS_TestCase {
+
+	const NODE_ID = 'a1b2c3d4';
+
+	/**
+	 * @test
+	 */
+	public function it_gets() {
+		$strings = [
+			new WPML_PB_String( 'something', 'some name', 'some title', 'LINE' ), // initial string
+		];
+
+		$fields = [
+			[
+				'_id'     => 'id_1',
+				'field_A' => self::get_string_value( 'field_A', 'id_1' ),
+				'field_B' => [ 'inner_field_B' => self::get_string_value( 'inner_field_B', 'id_1' ) ],
+			],
+			[
+				'_id'            => 'id_2',
+				'field_A'        => self::get_string_value( 'field_A', 'id_2' ),
+				'not_translated' => 'not translated field',
+			],
+		];
+
+		$element = self::get_element( $fields );
+
+		$expected_strings = array_merge(
+			$strings,
+			[
+				$this->get_string( 'field_A', 'id_1' ),
+				$this->get_string( 'inner_field_B', 'id_1' ),
+				$this->get_string( 'field_A', 'id_2' ),
+			]
+		);
+
+		$subject = new WPML_Elementor_Module_With_Items_For_Test();
+
+		$this->assertEquals( $expected_strings, $subject->get( self::NODE_ID, $element, $strings ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_updates_a_field() {
+		$translated_value = 'the translated value';
+
+		$string = $this->get_string( 'field_A', 'id_2' );
+		$string->set_value( $translated_value );
+
+		$field_to_translate = [
+			'_id'            => 'id_2',
+			'field_A'        => 'something to translate',
+			'not_translated' => 'not translated field',
+		];
+
+		$expected_translated_field            = $field_to_translate;
+		$expected_translated_field['field_A'] = $translated_value;
+		// We are modifying the field, and this 'index' will be used outside the class...
+		$expected_translated_field['index']   = 1;
+
+		$fields = [
+			[
+				'_id'     => 'id_1',
+				'field_A' => 'some value for field_A - id_1',
+				'field_B' => [ 'inner_field_B' => 'some value for inner_field_B - id_1' ],
+			],
+			$field_to_translate,
+			[
+				'_id'     => 'id_3',
+				'field_A' => 'some value for field_A - id_3',
+				'field_B' => [ 'inner_field_B' => 'some value for inner_field_B - id_3' ],
+			],
+		];
+
+		$element = self::get_element( $fields );
+
+		$subject = new WPML_Elementor_Module_With_Items_For_Test();
+
+		$this->assertEquals(
+			$expected_translated_field,
+			$subject->update( self::NODE_ID, $element, $string )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_updates_a_inner_field() {
+		$translated_value = 'the translated value';
+
+		$string = $this->get_string( 'inner_field_B', 'id_2' );
+		$string->set_value( $translated_value );
+
+		$field_to_translate = [
+			'_id'            => 'id_2',
+			'field_A'        => 'something',
+			'field_B'        => [
+				'foo'           => 'bar',
+				'inner_field_B' => 'TO BE TRANSLATED',
+				'hello'         => 'there',
+			],
+		];
+
+		$expected_translated_field                             = $field_to_translate;
+		$expected_translated_field['field_B']['inner_field_B'] = $translated_value;
+		// We are modifying the field, and this 'index' will be used outside the class...
+		$expected_translated_field['index'] = 1;
+
+		$fields = [
+			[
+				'_id'     => 'id_1',
+				'field_A' => 'some value for field_A - id_1',
+				'field_B' => [ 'inner_field_B' => 'some value for inner_field_B - id_1' ],
+			],
+			$field_to_translate,
+			[
+				'_id'     => 'id_3',
+				'field_A' => 'some value for field_A - id_3',
+				'field_B' => [ 'inner_field_B' => 'some value for inner_field_B - id_3' ],
+			],
+		];
+
+		$element = self::get_element( $fields );
+
+		$subject = new WPML_Elementor_Module_With_Items_For_Test();
+
+		$this->assertEquals(
+			$expected_translated_field,
+			$subject->update( self::NODE_ID, $element, $string )
+		);
+	}
+
+	public static function get_string_value( $name, $item_id ) {
+		return "The value for $name - $item_id";
+	}
+
+	public static function get_field_prop( $field, $prop ) {
+		return "The $prop for $field";
+	}
+
+	private static function get_string( $field, $item_id ) {
+		return new WPML_PB_String(
+			self::get_string_value( $field, $item_id ),
+			WPML_Elementor_Module_With_Items_For_Test::WIDGET_TYPE . '-' . $field . '-' . Test_WPML_Elementor_Module_With_Items::NODE_ID . '-' . $item_id,
+			Test_WPML_Elementor_Module_With_Items::get_field_prop( $field, 'title' ),
+			Test_WPML_Elementor_Module_With_Items::get_field_prop( $field, 'type' )
+		);
+	}
+
+	private static function get_element( array $fields ) {
+		return [
+			WPML_Elementor_Translatable_Nodes::TYPE           => WPML_Elementor_Module_With_Items_For_Test::WIDGET_TYPE,
+			WPML_Elementor_Translatable_Nodes::SETTINGS_FIELD => [
+				'test_field' => $fields,
+			],
+		];
+	}
+}
+
+class WPML_Elementor_Module_With_Items_For_Test extends WPML_Elementor_Module_With_Items {
+
+	const WIDGET_TYPE = 'nice-widget';
+
+	public function get_fields() {
+		return [
+			'first_missing_field_in_widget',
+			'field_A',
+			'field_B' => [
+				'first_missing_inner_field',
+				'inner_field_B',
+				'second_missing_inner_field',
+			],
+			'second_missing_field_in_widget',
+		];
+	}
+
+	protected function get_title( $field ) {
+		return Test_WPML_Elementor_Module_With_Items::get_field_prop( $field, 'title' );
+	}
+
+	protected function get_editor_type( $field ) {
+		return Test_WPML_Elementor_Module_With_Items::get_field_prop( $field, 'type' );
+	}
+
+	public function get_items_field() {
+		return 'test_field';
+	}
+}

--- a/tests/phpunit/tests/modules/test-wpml-elementor-form.php
+++ b/tests/phpunit/tests/modules/test-wpml-elementor-form.php
@@ -13,7 +13,17 @@ class Test_WPML_Elementor_Form extends OTGS_TestCase {
 	 */
 	public function it_get_fields() {
 
-		$expected = array( 'field_label', 'placeholder', 'field_html', 'acceptance_text', 'field_options' );
+		$expected = [
+			'field_label',
+			'placeholder',
+			'field_html',
+			'acceptance_text',
+			'field_options',
+			'step_next_label',
+			'step_previous_label',
+			'previous_button',
+			'next_button',
+		];
 		$subject = new WPML_Elementor_Form();
 		$this->assertEquals( $expected, $subject->get_fields() );
 	}


### PR DESCRIPTION
I also added one commit to fix an missing array index. Not sure if it's an old or new problem. It's possible that the element keys are different from one version to another. We should fix it anyway...

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7275