### PR TITLE
Add the ability to translate self-hosted video an external url for Elementor

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -275,6 +275,16 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 						'type'        => __( 'Video: DailyMotion URL', 'sitepress' ),
 						'editor_type' => 'LINE'
 					),
+					'hosted_url'=> array(
+						'field'       => 'url',
+						'type'        => __( 'Video: Self hosted', 'sitepress' ),
+						'editor_type' => 'LINE'
+					),
+					'external_url'=> array(
+						'field'       => 'url',
+						'type'        => __( 'Video: External hosted', 'sitepress' ),
+						'editor_type' => 'LINE'
+					),
 				),
 			),
 			'login'       => array(


### PR DESCRIPTION
Adding the elements to our configuration, so that self-hosted video and external url video can be translated in the translation editor.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7154