### PR TITLE
[wpmlcore-7279] Search widget fix with language as parameter

### DIFF
--- a/src/Hooks/Frontend.php
+++ b/src/Hooks/Frontend.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+class Frontend implements \IWPML_Frontend_Action {
+
+    public function add_hooks() {
+        add_action( 'elementor_pro/search_form/after_input', [ $this, 'addLanguageFormField' ] );
+    }
+
+    public function addLanguageFormField() {
+        do_action( 'wpml_add_language_form_field' );
+    }
+
+
+}

--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -24,6 +24,7 @@ class WPML_Elementor_Integration_Factory {
 				\WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
 				\WPML\PB\Elementor\Hooks\DynamicElements::class,
 				\WPML\PB\Elementor\Hooks\GutenbergCleanup::class,
+				\WPML\PB\Elementor\Hooks\Frontend::class,
 			)
 		);
 

--- a/tests/phpunit/tests/Hooks/TestFrontend.php
+++ b/tests/phpunit/tests/Hooks/TestFrontend.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+/**
+ * @group hooks
+ * @group frontend
+ * @group wpmlcore-7279
+ */
+class TestFrontend extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = new Frontend();
+		\WP_Mock::expectActionAdded( 'elementor_pro/search_form/after_input', [ $subject, 'addLanguageFormField' ] );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddLanguageFormField() {
+		$subject = new Frontend();
+		\WP_Mock::expectAction( 'wpml_add_language_form_field' );
+		$subject->addLanguageFormField();
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -30,6 +30,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     \WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
 			                     \WPML\PB\Elementor\Hooks\DynamicElements::class,
 			                     \WPML\PB\Elementor\Hooks\GutenbergCleanup::class,
+			                     \WPML\PB\Elementor\Hooks\Frontend::class,
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );


### PR DESCRIPTION
[wpmlcore-7279] Add new class that is especially for Elementor search widget to handle different language search via hidden language parameter.
Add new class to be loaded on frontend actions

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7279