### PR TITLE
[wpmlcore-7223] Translate custom gallery titles in Elementor Pro

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -930,6 +930,24 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 					'\WPML\PB\Elementor\Modules\Reviews',
 				]
 			),
+			'galleries' => array(
+				'conditions'        => array( self::TYPE => 'gallery' ),
+				'fields'            => array(
+					array(
+						'field'       => 'show_all_galleries_label',
+						'type'        => __( 'All Gallery Label', 'sitepress' ),
+						'editor_type' => 'LINE'
+					),
+					'url' => array(
+						'field'       => 'url',
+						'type'        => __( 'Gallery custom link', 'sitepress' ),
+						'editor_type' => 'LINK'
+					),
+				),
+				'integration-class' => [
+					'\WPML\PB\Elementor\Modules\MulitpleGallery',
+				]
+			),
 		);
 	}
 

--- a/src/modules/MultipleGallery.php
+++ b/src/modules/MultipleGallery.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * MulitpleGallery
+ */
+namespace WPML\PB\Elementor\Modules;
+
+class MulitpleGallery extends \WPML_Elementor_Module_With_Items {
+
+    protected function get_title( $field ) {
+        switch ( $field ) {
+            case 'gallery_title':
+                return esc_html__( 'Gallery Title:', 'sitepress' );
+            default:
+                return '';
+        }
+    }
+
+    public function get_fields() {
+        return [ 'gallery_title' ];
+    }
+
+    protected function get_editor_type( $field ) {
+        if ( 'gallery_title' === $field ) {
+            return 'LINE';
+        }
+    }
+
+    public function get_items_field() {
+        return 'galleries';
+    }
+}

--- a/tests/phpunit/tests/modules/TestMultipleGallery.php
+++ b/tests/phpunit/tests/modules/TestMultipleGallery.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace WPML\PB\Elementor\Modules;
+
+/**
+ * @group modules
+ * @group wpmlcore-7223
+ */
+class TestMultipleGallery extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_get_fields() {
+		$subject = new MulitpleGallery();
+		$this->assertEquals( [ 'gallery_title' ], $subject->get_fields() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_get_items_field() {
+		$subject = new MulitpleGallery();
+		$this->assertEquals( 'galleries', $subject->get_items_field() );
+	}
+}


### PR DESCRIPTION
Add the ability to translate the custom Elementor gallery title, "all" galleries element and if a custom link is set to the gallery

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7223