### PR TITLE
Prevent mix of string packages if a post was initially edited with Gutenberg and then with Elementor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,10 @@
     "otgs/unit-tests-framework": "~1.2.0",
     "wpml/page-builders": "dev-master",
     "elementor/elementor": "dev-master",
-    "wpml/collect": "dev-wpml-collect-rename"
+    "wpml/collect": "dev-wpml-collect-rename",
+    "wpml/fp": "^0.1.1",
+    "wpml/wp": "^0.1.1",
+    "composer/composer": "^1.10"
   },
   "scripts": {
     "post-update-cmd": [

--- a/src/DataConvert.php
+++ b/src/DataConvert.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WPML\PB\Elementor;
+
+class DataConvert {
+
+	/**
+	 * @param array $data
+	 *
+	 * @return string
+	 */
+	public static function serialize( array $data ) {
+		return wp_slash( wp_json_encode( $data ) );
+	}
+
+	/**
+	 * @param array|string $data
+	 *
+	 * @return array
+	 */
+	public static function unserialize( $data ) {
+		return json_decode( is_array( $data ) ? $data[0] : $data, true );
+	}
+}

--- a/src/Hooks/GutenbergCleanup.php
+++ b/src/Hooks/GutenbergCleanup.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+use WPML\FP\Fns;
+use WPML\FP\Logic;
+use WPML\FP\Maybe;
+use WPML\FP\Relation;
+use WPML\LIB\WP\Post;
+use WPML\PB\Elementor\DataConvert;
+use WPML_Elementor_Data_Settings;
+use function WPML\FP\curryN;
+use function WPML\FP\pipe;
+
+class GutenbergCleanup implements \IWPML_Backend_Action, \IWPML_Frontend_Action {
+
+	public function add_hooks() {
+		add_filter(
+			'update_post_metadata',
+			Fns::withoutRecursion( Fns::identity(), [ $this, 'removeGutenbergFootprint' ] ),
+			10,
+			4
+		);
+	}
+
+	/**
+	 * If we detect Gutenberg footprint in the Elementor data,
+	 * we'll remove it and delete the Gutenberg string package.
+	 *
+	 * @param null|bool $check
+	 * @param int       $postId
+	 * @param string    $metaKey
+	 * @param string    $metaValue
+	 *
+	 * @return mixed
+	 */
+	public function removeGutenbergFootprint( $check, $postId, $metaKey, $metaValue ) {
+		if (
+			WPML_Elementor_Data_Settings::META_KEY_DATA === $metaKey
+			&& WPML_Elementor_Data_Settings::is_edited_with_elementor( $postId )
+		) {
+			// $ifValueHasChanged :: string -> bool
+			$ifValueHasChanged = pipe( Relation::equals( $metaValue ), Logic::not() );
+
+			// $update :: int -> string -> bool
+			$update = curryN( 2, function( $postId, $meta ) {
+				Post::updateMeta( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA, $meta );
+				self::deletePackage( self::getGutenbergPackage( $postId ) );
+				return true;
+			} );
+
+			return Maybe::of( $metaValue )
+				->map( [ DataConvert::class, 'unserialize' ] )
+				->map( [ $this, 'removeBlockMetaInEditorWidget' ] )
+				->map( [ DataConvert::class, 'serialize' ] )
+				->filter( $ifValueHasChanged )
+				->map( $update( $postId ) )
+				->getOrElse( $check );
+		}
+
+		return $check;
+	}
+
+	/**
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	public function removeBlockMetaInEditorWidget( array $data ) {
+		foreach ( $data as &$element ) {
+			if ( $element['elements'] ) {
+				$element['elements'] = $this->removeBlockMetaInEditorWidget( $element['elements'] );
+			} elseif ( 'widget' === $element['elType'] && isset( $element['settings']['editor'] ) ) {
+				$element['settings']['editor'] = preg_replace( '(<!--[^<]*-->)', '', $element['settings']['editor'] );
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @param int $postId
+	 */
+	public static function getGutenbergPackage( $postId ) {
+		// $isGbPackage :: \WPML_Package -> bool
+		$isGbPackage = Relation::propEq( 'kind_slug', 'gutenberg' );
+
+		return wpml_collect( apply_filters( 'wpml_st_get_post_string_packages', [], $postId ) )
+			->filter( $isGbPackage )
+			->first();
+	}
+
+	/**
+	 * @param \WPML_Package|null $package
+	 */
+	public static function deletePackage( $package ) {
+		$package && do_action( 'wpml_delete_package', $package->name, $package->kind );
+	}
+}

--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -1,6 +1,11 @@
 <?php
 
+use WPML\PB\Elementor\DataConvert;
+
 class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings {
+
+	const META_KEY_DATA = '_elementor_data';
+	const META_KEY_MODE = '_elementor_edit_mode';
 
 	/**
 	 * @var WPML_Elementor_DB
@@ -57,7 +62,7 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 * @return string
 	 */
 	public function get_meta_field() {
-		return '_elementor_data';
+		return self::META_KEY_DATA;
 	}
 
 	/**
@@ -73,7 +78,7 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	public function get_fields_to_copy() {
 		return array(
 			'_elementor_version',
-			'_elementor_edit_mode',
+			self::META_KEY_MODE,
 			'_elementor_css',
 			'_elementor_template_type',
 			'_elementor_template_widget_type',
@@ -86,12 +91,7 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 * @return array
 	 */
 	public function convert_data_to_array( $data ) {
-		$converted_data = $data;
-		if ( is_array( $data ) ) {
-			$converted_data = $data[0];
-		}
-
-		return json_decode( $converted_data, true );
+		return DataConvert::unserialize( $data );
 	}
 
 	/**
@@ -100,7 +100,7 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 * @return string
 	 */
 	public function prepare_data_for_saving( array $data ) {
-		return wp_slash( wp_json_encode( $data ) );
+		return DataConvert::serialize( $data );
 	}
 
 	/**
@@ -135,6 +135,15 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 */
 	public function is_handling_post( $postId ) {
 		return (bool) get_post_meta( $postId, $this->get_meta_field(), true )
-			&& 'builder' === get_post_meta( $postId, '_elementor_edit_mode', true );
+			&& self::is_edited_with_elementor( $postId );
+	}
+
+	/**
+	 * @param int $postId
+	 *
+	 * @return bool
+	 */
+	public static function is_edited_with_elementor( $postId ) {
+		return 'builder' === get_post_meta( $postId, self::META_KEY_MODE, true );
 	}
 }

--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -23,6 +23,7 @@ class WPML_Elementor_Integration_Factory {
 				'WPML_Elementor_WooCommerce_Hooks_Factory',
 				\WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
 				\WPML\PB\Elementor\Hooks\DynamicElements::class,
+				\WPML\PB\Elementor\Hooks\GutenbergCleanup::class,
 			)
 		);
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -47,3 +47,33 @@ require_once ELEMENTOR_PATH . '/includes/base/widget-base.php';
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';
+
+try {
+	if ( ! spl_autoload_register( 'autoload_tests_classes' ) ) {
+		echo 'Test classes cannot be loaded!';
+		exit( 1 );
+	}
+} catch ( Exception $e ) {
+	echo $e->getMessage();
+	exit( 1 );
+}
+
+function autoload_tests_classes( $class ) {
+	static $maps;
+
+	if ( ! $maps ) {
+		$dirs = [
+			__DIR__ . '/../../vendor/wpml/wp/tests/mocks',
+		];
+
+		$maps = [];
+		foreach ( $dirs as $dir ) {
+			$maps = array_merge( $maps, \Composer\Autoload\ClassMapGenerator::createMap( $dir ) );
+		}
+	}
+
+	if ( $maps && array_key_exists( $class, $maps ) ) {
+		/** @noinspection PhpIncludeInspection */
+		require_once $maps[ $class ];
+	}
+}

--- a/tests/phpunit/tests/Hooks/TestGutenbergCleanup.php
+++ b/tests/phpunit/tests/Hooks/TestGutenbergCleanup.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+use tad\FunctionMocker\FunctionMocker;
+use WPML\FP\Fns;
+use WPML\LIB\WP\PostMock;
+use WPML\LIB\WP\Post;
+use WPML_Elementor_Data_Settings;
+
+/**
+ * @group hooks
+ * @group gutenberg-cleanup
+ */
+class TestGutenbergCleanup extends \OTGS_TestCase {
+
+	use PostMock;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->setUpPostMock();
+
+		\WP_Mock::passthruFunction( 'wp_slash' );
+		\WP_Mock::userFunction( 'wp_json_encode', [
+			'return' => function( $value ) {
+				return json_encode( $value );
+			},
+		] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = new GutenbergCleanup();
+
+		\WP_Mock::expectFilterAdded(
+			'update_post_metadata',
+			Fns::withoutRecursion( Fns::identity(), [ $subject, 'removeGutenbergFootprint' ] ),
+			10,
+			4
+		);
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNOTRemoveGbFootprintIfNotElementorDataMeta() {
+		$check     = 'some boolean';
+		$postId    = 123;
+		$metaKey   = 'some key';
+		$metaValue = 'some value';
+
+		$subject = new GutenbergCleanup();
+
+		$this->assertSame(
+			$check,
+			$subject->removeGutenbergFootprint( $check, $postId, $metaKey, $metaValue )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNOTRemoveGbFootprintIfPostNOTEditedWithElementor() {
+		$check     = 'some boolean';
+		$postId    = 123;
+		$metaKey   = WPML_Elementor_Data_Settings::META_KEY_DATA;
+		$metaValue = 'some value';
+
+		Post::updateMeta( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA, $metaValue );
+
+		$isEditedWithElementor = FunctionMocker::replace( WPML_Elementor_Data_Settings::class . '::is_edited_with_elementor', false );
+
+		$subject = new GutenbergCleanup();
+
+		$this->assertSame(
+			$check,
+			$subject->removeGutenbergFootprint( $check, $postId, $metaKey, $metaValue )
+		);
+
+		$isEditedWithElementor->wasCalledWithOnce( [ $postId ] );
+		$this->assertEquals( $metaValue, Post::getMetaSingle( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldNOTRemoveGbFootprintIfNOBlockIsFound() {
+		$check     = 'some boolean';
+		$postId    = 123;
+		$metaKey   = WPML_Elementor_Data_Settings::META_KEY_DATA;
+		$metaValue = self::getMetaValue( '<p><\/p>\n<p>Something sure!<\/p>\n<p><\/p>' );
+
+		Post::updateMeta( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA, $metaValue );
+
+		$isEditedWithElementor = FunctionMocker::replace( WPML_Elementor_Data_Settings::class . '::is_edited_with_elementor', true );
+
+		\WP_Mock::userFunction( 'update_post_metadata' )->never();
+
+		$subject = new GutenbergCleanup();
+
+		$this->assertSame(
+			$check,
+			$subject->removeGutenbergFootprint( $check, $postId, $metaKey, $metaValue )
+		);
+
+		$isEditedWithElementor->wasCalledWithOnce( [ $postId ] );
+		$this->assertEquals( $metaValue, Post::getMetaSingle( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldRemoveGbFootprintIfOneBlockIsFound() {
+		$check        = 'some boolean';
+		$postId       = 123;
+		$metaKey      = WPML_Elementor_Data_Settings::META_KEY_DATA;
+		$metaValue    = self::getMetaValue( '<p><!-- wp:paragraph --><\/p><!-- /wp:paragraph -->\n<p>Something sure!<\/p>\n<p><\/p>' );
+		$newMetaValue = self::getMetaValue( '<p><\/p>\n<p>Something sure!<\/p>\n<p><\/p>' );
+
+		Post::updateMeta( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA, $metaValue );
+
+		$elementorPackage = $this->getPackage( 'elementor', $postId );
+		$gutenbergPackage = $this->getPackage( 'gutenberg', $postId );
+		$unknownPackage   = $this->getPackage( 'unknown', $postId );
+
+		$isEditedWithElementor = FunctionMocker::replace( WPML_Elementor_Data_Settings::class . '::is_edited_with_elementor', true );
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $postId )
+			->reply( [ $elementorPackage, $gutenbergPackage, $unknownPackage ] );
+
+		$deleteAction = FunctionMocker::replace( 'do_action' );
+
+		$subject = new GutenbergCleanup();
+
+		$this->assertTrue(
+			$subject->removeGutenbergFootprint( $check, $postId, $metaKey, $metaValue )
+		);
+
+		$isEditedWithElementor->wasCalledWithOnce( [ $postId ] );
+		$this->assertEquals( $newMetaValue, Post::getMetaSingle( $postId, WPML_Elementor_Data_Settings::META_KEY_DATA ) );
+		$deleteAction->wasCalledWithOnce( [ 'wpml_delete_package', $gutenbergPackage->name, $gutenbergPackage->kind ] );
+	}
+
+	private static function getMetaValue( $editorContent ) {
+		return '[{"id":"dc45eec","elType":"section","settings":[],"elements":[{"id":"761adbdf","elType":"column","settings":{"_column_size":100},"elements":[{"id":"88004c2","elType":"widget","settings":{"title":"Add Your Heading Text Here"},"elements":[],"widgetType":"heading"},{"id":"888e41","elType":"widget","settings":{"editor":"' . $editorContent . '","__globals__":{"text_color":"globals\/colors?id=accent"}},"elements":[],"widgetType":"text-editor"}],"isInner":false}],"isInner":false}]';
+	}
+
+	private function getPackage( $kind, $name ) {
+		$package = $this->getMockBuilder( '\WPML_Package' )->getMock();
+		$package->kind_slug = strtolower( $kind );
+		$package->kind      = strtoupper( $kind );
+		$package->name      = $name;
+
+		return $package;
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -29,6 +29,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     'WPML_Elementor_WooCommerce_Hooks_Factory',
 			                     \WPML\PB\Elementor\LanguageSwitcher\LanguageSwitcher::class,
 			                     \WPML\PB\Elementor\Hooks\DynamicElements::class,
+			                     \WPML\PB\Elementor\Hooks\GutenbergCleanup::class,
 		                     ) );
 
 		$string_registration = \Mockery::mock( 'overload:WPML_PB_String_Registration' );


### PR DESCRIPTION
When Elementor is saving its data, we'll try to:
- detect some Gutenberg block meta data in all editor widgets and remove it
- if Elementor's data has changed, update the data
- remove the Gutenberg package

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7444