### PR TITLE
Remove data post meta from post hash when auto-update is activated

### DIFF
--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -124,7 +124,12 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 * @return array
 	 */
 	public function add_data_custom_field_to_md5( array $custom_fields_values, $post_id ) {
-		$custom_fields_values[] = get_post_meta( $post_id, $this->get_meta_field(), true );
+		if ( apply_filters( 'wpml_pb_auto_update_enabled', false ) ) {
+			unset( $custom_fields_values[ $this->get_meta_field() ] );
+		} else {
+			$custom_fields_values[ $this->get_meta_field() ] = get_post_meta( $post_id, $this->get_meta_field(), true );
+		}
+
 		return $custom_fields_values;
 	}
 

--- a/tests/phpunit/tests/test-wpml-elementor-data-settings.php
+++ b/tests/phpunit/tests/test-wpml-elementor-data-settings.php
@@ -164,21 +164,50 @@ class Test_WPML_Elementor_Data_Settings extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_adds_custom_field() {
+		\WP_Mock::onFilter( 'wpml_pb_auto_update_enabled' )
+		        ->with( false )
+		        ->reply( false );
+
 		$subject = new WPML_Elementor_Data_Settings();
 
-		$custom_field_values = array( 'cf1', 'cf2' );
-		$pb_cf_value = rand_str( 10 );
-		$post_id = mt_rand();
+		$custom_field_values = [ 'cf1', 'cf2' ];
+		$pb_cf_value         = 'Some Elementor data';
+		$post_id             = 123;
 
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'args'   => array( $post_id, '_elementor_data', true ),
+		\WP_Mock::userFunction( 'get_post_meta', [
+			'args'   => [ $post_id, '_elementor_data', true ],
 			'return' => $pb_cf_value,
-		) );
+		] );
 
-		$expected = $custom_field_values;
-		$expected[] = $pb_cf_value;
+		$expected                    = $custom_field_values;
+		$expected['_elementor_data'] = $pb_cf_value;
 
 		$this->assertEquals( $expected, $subject->add_data_custom_field_to_md5( $custom_field_values, $post_id ) );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-7544
+	 */
+	public function it_removes_custom_field_if_auto_update_activated() {
+		\WP_Mock::onFilter( 'wpml_pb_auto_update_enabled' )
+			->with( false )
+			->reply( true );
+
+		$custom_field_values = [
+			'cf1' => 'cf1 value',
+			WPML_Elementor_Data_Settings::META_KEY_DATA => 'Some Elementor data',
+			'cf2' => 'cf2 value',
+		];
+
+		$expected = [
+			'cf1' => 'cf1 value',
+			'cf2' => 'cf2 value',
+		];
+
+		$subject = new WPML_Elementor_Data_Settings();
+
+		$this->assertEquals( $expected, $subject->add_data_custom_field_to_md5( $custom_field_values, 123 ) );
 	}
 
 	/**


### PR DESCRIPTION
**Goes with https://github.com/OnTheGoSystems/wpml-page-builders/pull/109**

We'll keep the old behavior in case the translation auto-update feature
is disabled.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7544