### PR TITLE
Remove data post meta from post hash when auto-update is enabled

### DIFF
--- a/src/class-wpml-elementor-data-settings.php
+++ b/src/class-wpml-elementor-data-settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use WPML\PB\AutoUpdate\Settings as AutoUpdateSettings;
 use WPML\PB\Elementor\DataConvert;
 
 class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings {
@@ -124,7 +125,12 @@ class WPML_Elementor_Data_Settings implements IWPML_Page_Builders_Data_Settings 
 	 * @return array
 	 */
 	public function add_data_custom_field_to_md5( array $custom_fields_values, $post_id ) {
-		$custom_fields_values[] = get_post_meta( $post_id, $this->get_meta_field(), true );
+		if ( AutoUpdateSettings::isEnabled() ) {
+			unset( $custom_fields_values[ $this->get_meta_field() ] );
+		} else {
+			$custom_fields_values[ $this->get_meta_field() ] = get_post_meta( $post_id, $this->get_meta_field(), true );
+		}
+
 		return $custom_fields_values;
 	}
 


### PR DESCRIPTION
We'll keep the old behavior in case the translation auto-update feature
is disabled.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7544