### PR TITLE
Introduce the generic class `ModuleWithItemsFromConfig`

### DIFF
--- a/src/class-wpml-elementor-translatable-nodes.php
+++ b/src/class-wpml-elementor-translatable-nodes.php
@@ -1,6 +1,7 @@
 <?php
 
 use WPML\PB\Elementor\DynamicContent\Strings as DynamicContentStrings;
+use WPML\PB\Elementor\Modules\ModuleWithItemsFromConfig;
 
 /**
  * Class WPML_Elementor_Translatable_Nodes
@@ -154,6 +155,12 @@ class WPML_Elementor_Translatable_Nodes implements IWPML_Page_Builders_Translata
 					} catch ( Exception $e ) {
 					}
 				}
+			}
+		}
+
+		if ( isset( $node_data['fields_in_item'] ) ) {
+			foreach ( $node_data['fields_in_item'] as $item_of => $config ) {
+				$instances[] = new ModuleWithItemsFromConfig( $item_of, $config );
 			}
 		}
 

--- a/src/modules/ModuleWithItemsFromConfig.php
+++ b/src/modules/ModuleWithItemsFromConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace WPML\PB\Elementor\Modules;
+
+use WPML\FP\Obj;
+
+class ModuleWithItemsFromConfig extends \WPML_Elementor_Module_With_Items {
+
+	/** @var array $fields */
+	private $fields = [];
+
+	/** @var array $fieldDefinitions */
+	private $fieldDefinitions = [];
+
+	/** @var string $itemsField */
+	private $itemsField;
+
+	/**
+	 * @param string $itemsField
+	 * @param array  $config
+	 */
+	public function __construct( $itemsField, array $config ) {
+		$this->itemsField = $itemsField;
+		$this->init( $config );
+	}
+
+	private function init( array $config ) {
+		foreach ( $config as $key => $fieldConfig ) {
+			$field = Obj::prop( 'field', $fieldConfig );
+			$keyOf = is_string( $key ) ? $key : null;
+
+			if ( $keyOf ) {
+				$this->fields[ $keyOf ] = [ $field ];
+			} else {
+				$this->fields[] = $field;
+			}
+
+			$this->fieldDefinitions[ $field ] = $fieldConfig;
+		}
+	}
+
+	private function getFieldData( $field, $key ) {
+		return Obj::path( [ $field, $key ], $this->fieldDefinitions );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_title( $field ) {
+		return $this->getFieldData( $field, 'type' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_fields() {
+		return $this->fields;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_editor_type( $field ) {
+		return $this->getFieldData( $field, 'editor_type' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_items_field() {
+		return $this->itemsField;
+	}
+}

--- a/tests/phpunit/tests/modules/TestModuleWithItemsFromConfig.php
+++ b/tests/phpunit/tests/modules/TestModuleWithItemsFromConfig.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WPML\PB\Elementor\Modules;
+
+/**
+ * @group modules
+ */
+class TestModuleWithItemsFromConfig extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldGetData() {
+		$itemsField = 'slides';
+
+		$config = [
+			[
+				'field'       => 'title',
+				'type'        => 'The slide title',
+				'editor_type' => 'LINE',
+			],
+			'link' => [
+				'field'       => 'url',
+				'type'        => 'The slide url',
+				'editor_type' => 'LINK',
+			],
+		];
+
+
+		$subject = new ModuleWithItemsFromConfig( $itemsField, $config );
+
+		$this->assertEquals( $itemsField, $subject->get_items_field() );
+
+		$this->assertEquals(
+			[ 'title', 'link' => [ 'url' ] ],
+			$subject->get_fields()
+		);
+
+		// Title field
+		$this->assertEquals( 'The slide title', $subject->get_title( 'title' ) );
+		$this->assertEquals( 'LINE', $subject->get_editor_type( 'title' ) );
+
+		// Link field
+		$this->assertEquals( 'The slide url', $subject->get_title( 'url' ) );
+		$this->assertEquals( 'LINK', $subject->get_editor_type( 'url' ) );
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translatable-nodes.php
@@ -542,6 +542,67 @@ class Test_WPML_Elementor_Translatable_Nodes extends OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-7565
+	 */
+	public function it_gets_strings_from_fields_in_item_config() {
+		$widgetType  = 'slide';
+		$itemsField  = 'slides';
+		$field       = 'title';
+		$stringValue = 'The nice title';
+		$type        = 'Slide Title';
+		$editorType  = 'LINE';
+		$nodeId      = '1a2b3c4d';
+		$itemId      = 'slide1';
+
+		$nodes = [
+			[
+				'conditions'     => [ 'widgetType' => $widgetType ],
+				'fields'         => [],
+				'fields_in_item' => [
+					$itemsField => [
+						[
+							'field'       => $field,
+							'type'        => $type,
+							'editor_type' => $editorType,
+						],
+					],
+				],
+			],
+		];
+
+		\WP_Mock::onFilter( 'wpml_elementor_widgets_to_translate' )
+		        ->with( WPML_Elementor_Translatable_Nodes::get_nodes_to_translate() )
+		        ->reply( $nodes );
+
+		$element = [
+			'widgetType' => $widgetType,
+			'settings'   => [
+				$itemsField => [
+					[
+						'_id'  => $itemId,
+						$field => $stringValue,
+					]
+				],
+			],
+		];
+
+		$stringName     = $widgetType . '-' . $field . '-' . $nodeId . '-' . $itemId;
+		$expectedString = new WPML_PB_String( $stringValue, $stringName, $type, $editorType );
+
+		FunctionMocker::replace(
+			DynamicContentStrings::class . '::filter',
+			function( $strings ) { return $strings; }
+		);
+
+		$subject = new WPML_Elementor_Translatable_Nodes();
+		$strings = $subject->get( $nodeId, $element );
+
+		$this->assertCount( 1, $strings );
+		$this->assertEquals( $expectedString, $strings[0] );
+	}
+
+	/**
+	 * @test
 	 * @group wpmlcore-6436
 	 */
 	public function it_updates() {


### PR DESCRIPTION
**Requires https://github.com/OnTheGoSystems/wpml-page-builders/pull/116**

This new class receives static data from the configuration file and
should allow to replace all existing module integration classes.

=> Here's an example of how we'll proceed https://github.com/OnTheGoSystems/wpml-page-builders-elementor/pull/127.


https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7565