### PR TITLE
[wpmlcore-7565] NOT TO MERGE - FOR DEMO ONLY

### DIFF
--- a/tests/phpunit/tests/modules/TestMediaCarousel.php
+++ b/tests/phpunit/tests/modules/TestMediaCarousel.php
@@ -12,7 +12,13 @@ class TestMediaCarousel extends \OTGS_TestCase {
 	 * @test
 	 */
 	public function it_get_fields() {
-		$subject = new MediaCarousel();
+		$config = [
+			'image_link_to'	=> [
+				'field' => 'url',
+			],
+		];
+
+		$subject = new ModuleWithItemsFromConfig( 'slides', $config );
 		$this->assertEquals( [ 'image_link_to' => [ 'url' ] ], $subject->get_fields() );
 	}
 
@@ -20,7 +26,7 @@ class TestMediaCarousel extends \OTGS_TestCase {
 	 * @test
 	 */
 	public function it_get_items_field() {
-		$subject = new MediaCarousel();
+		$subject = new ModuleWithItemsFromConfig( 'slides', [] );
 		$this->assertEquals( 'slides', $subject->get_items_field() );
 	}
 }


### PR DESCRIPTION
**Relates to https://github.com/OnTheGoSystems/wpml-page-builders-elementor/pull/126**

Here's an example of how we can migrate our module integration classes to the config file. Then we won't have any integration class on our side.

Note 1: Here the existing test is not covering all the methods, it's just an example to understand how we'll proceed.

Note 2: We'll keep the ability to have integration class because I know some external plugins created their own integration classes for their custom widgets.