### PR TITLE
Translate id with Any Child Of condition

### DIFF
--- a/src/class-wpml-elementor-translate-ids.php
+++ b/src/class-wpml-elementor-translate-ids.php
@@ -110,7 +110,7 @@ class WPML_Elementor_Translate_IDs implements IWPML_Action {
 	 * @return int
 	 */
 	private function translate_id( $element_id, $element_type = null ) {
-		if ( ! $element_type ) {
+		if ( ! $element_type || $element_type === "any_child_of" ) {
 			$element_type = get_post_type( $element_id );
 		}
 

--- a/tests/phpunit/tests/test-wpml-elementor-translate-ids.php
+++ b/tests/phpunit/tests/test-wpml-elementor-translate-ids.php
@@ -373,4 +373,26 @@ class Test_WPML_Elementor_Translate_IDs extends OTGS_TestCase {
 			),
 		);
 	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-7559
+	 */
+	public function it_should_translate_location_condition_any_child_of() {
+		$sub_id            = 123;
+		$translate_id      = 456;
+		$post_type         = 'page';
+		$parsed_conditions = [ 'sub_name' => 'any_child_of' ];
+
+		\WP_Mock::userFunction( 'get_post_type', [ 'args' => $sub_id, 'return' => $post_type ] );
+
+		\WP_Mock::onFilter( 'wpml_object_id' )
+		        ->with( $sub_id, $post_type, true )
+		        ->reply( $translate_id );
+
+		$subject = new WPML_Elementor_Translate_IDs( \Mockery::mock( '\WPML\Utils\DebugBackTrace' ) );
+
+		$this->assertEquals( $translate_id,
+			$subject->translate_location_condition_sub_id( (string) $sub_id, $parsed_conditions ) );
+	}
 }


### PR DESCRIPTION
When using Any Child Of condition for Elementor templates, make sure that we translate the ID

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7559