### PR TITLE
Fix Elementor posts widget pagination

### DIFF
--- a/src/class-wpml-elementor-urls.php
+++ b/src/class-wpml-elementor-urls.php
@@ -23,6 +23,7 @@ class WPML_Elementor_URLs implements IWPML_Action {
 
 	public function add_hooks() {
 		add_filter( 'elementor/document/urls/edit', array( $this, 'adjust_edit_with_elementor_url' ), 10, 2 );
+		add_filter( 'wpml_is_pagination_url_in_post', [ $this, 'is_pagination_url' ], 10, 3 );
 	}
 
 	public function adjust_edit_with_elementor_url( $url, $elementor_document ) {
@@ -36,5 +37,22 @@ class WPML_Elementor_URLs implements IWPML_Action {
 		}
 
 		return $this->language_converter->convert_admin_url_string( $url, $post_language );
+	}
+
+	/**
+	 * Check if the given URL is the pagination inside the post.
+	 *
+	 * @param bool $is_pagination_url_in_post
+	 * @param string $url URL to check
+	 * @param string $post_name Current post name
+	 *
+	 * @return bool
+	 */
+	public function is_pagination_url( $is_pagination_url_in_post, $url, $post_name ) {
+		return $is_pagination_url_in_post
+		       || (
+			       WPML_Elementor_Data_Settings::is_edited_with_elementor( get_the_ID() )
+			       && preg_match_all( "/$post_name\/([\d]*)\/$/", $url )
+		       );
 	}
 }

--- a/tests/phpunit/tests/test-wpml-elementor-urls.php
+++ b/tests/phpunit/tests/test-wpml-elementor-urls.php
@@ -18,6 +18,12 @@ class Test_WPML_Elementor_URLs extends OTGS_TestCase {
 			'adjust_edit_with_elementor_url'
 		), 10, 2 );
 
+
+		$this->expectFilterAdded( 'wpml_is_pagination_url_in_post', [
+			$subject,
+			'is_pagination_url'
+		], 10, 3 );
+
 		$subject->add_hooks();
 
 	}
@@ -88,7 +94,7 @@ class Test_WPML_Elementor_URLs extends OTGS_TestCase {
 		$current_language = \Mockery::mock( 'IWPML_Current_Language' );
 		$current_language->shouldReceive( 'get_current_language' )->andReturn( $site_language );
 
-		$subject = new WPML_Elementor_URLs(
+		$subject = $this->get_subject(
 			$element_factory,
 			$language_converter,
 			$current_language
@@ -100,4 +106,37 @@ class Test_WPML_Elementor_URLs extends OTGS_TestCase {
 		$this->assertEquals( $translated_url, $subject->adjust_edit_with_elementor_url( $original_url, $elementor_document ) );
 	}
 
+	/**
+	 * @test
+	 */
+	public function it_filters_pagination_in_post() {
+		$path      = 'index.php/elementor-post/2/';
+		$post_name = 'elementor-post';
+
+		$element_factory    = \Mockery::mock( 'WPML_Translation_Element_Factory' );
+		$language_converter = \Mockery::mock( 'IWPML_URL_Converter_Strategy' );
+		$current_language   = \Mockery::mock( 'IWPML_Current_Language' );
+
+		WP_Mock::userFunction( 'get_post_meta', [ 'return' => 'builder' ] );
+		WP_Mock::userFunction( 'get_the_ID', [ 'return' => 1 ] );
+
+		$subject = $this->get_subject(
+			$element_factory,
+			$language_converter,
+			$current_language
+		);
+
+		$this->assertSame(
+			true,
+			$subject->is_pagination_url( false, $path, $post_name )
+		);
+	}
+
+	private function get_subject( $element_factory, $language_converter, $current_language ) {
+		return new WPML_Elementor_URLs(
+			$element_factory,
+			$language_converter,
+			$current_language
+		);
+	}
 }

--- a/tests/phpunit/tests/test-wpml-elementor-urls.php
+++ b/tests/phpunit/tests/test-wpml-elementor-urls.php
@@ -18,11 +18,15 @@ class Test_WPML_Elementor_URLs extends OTGS_TestCase {
 			'adjust_edit_with_elementor_url'
 		), 10, 2 );
 
-
 		$this->expectFilterAdded( 'wpml_is_pagination_url_in_post', [
 			$subject,
 			'is_pagination_url'
 		], 10, 3 );
+
+		$this->expectFilterAdded( 'paginate_links', [
+			$subject,
+			'fix_pagination_link_with_language_param'
+		], 10, 1 );
 
 		$subject->add_hooks();
 
@@ -129,6 +133,47 @@ class Test_WPML_Elementor_URLs extends OTGS_TestCase {
 		$this->assertSame(
 			true,
 			$subject->is_pagination_url( false, $path, $post_name )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_fixes_pagination_link_with_langauge_param() {
+		$post_name         = 'elementor-post';
+		$lang              = 'de';
+		$link_without_lang = "http://example.com/$post_name/2/";
+		$link              = "http://example.com/$post_name/?lang=$lang/2/";
+		$proper_link       = "http://example.com/$post_name/2/?lang=$lang";
+
+		$element_factory    = \Mockery::mock( 'WPML_Translation_Element_Factory' );
+		$language_converter = \Mockery::mock( 'IWPML_URL_Converter_Strategy' );
+		$current_language   = \Mockery::mock( 'IWPML_Current_Language' );
+
+		$current_language->shouldReceive( 'get_current_language' )->andReturn( $lang );
+
+		$language_converter->shouldReceive( 'convert_url_string' )
+		                   ->with( $link_without_lang, $lang )
+		                   ->andReturn( $proper_link );
+
+		WP_Mock::userFunction( 'get_post_meta', [ 'return' => 'builder' ] );
+		WP_Mock::userFunction( 'get_the_ID', [ 'return' => 1 ] );
+		WP_Mock::userFunction( 'get_post', [
+			'return' => (object) [
+				'ID'   => 1,
+				'post_name' => $post_name
+			]
+		] );
+
+		$subject = $this->get_subject(
+			$element_factory,
+			$language_converter,
+			$current_language
+		);
+
+		$this->assertSame(
+			$proper_link,
+			$subject->fix_pagination_link_with_language_param( $link )
 		);
 	}
 


### PR DESCRIPTION
Fix Elementor posts widget pagination when page is displayed as translated

It uses the filter from MR: https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/-/merge_requests/2884

wpmlcore-7482