### PR TITLE
[wpmlcore-7615] Fix Media Carousel Video URL not translatable

### DIFF
--- a/src/modules/MediaCarousel.php
+++ b/src/modules/MediaCarousel.php
@@ -15,7 +15,10 @@ class MediaCarousel extends \WPML_Elementor_Module_With_Items {
 	 * @return array
 	 */
 	public function get_fields() {
-		return [ 'image_link_to' => [ 'url' ] ];
+		return [ 
+			'image_link_to' => [ 'url' ],
+			'video' => [ 'url ']
+		];
 	}
 
 	/**
@@ -26,7 +29,7 @@ class MediaCarousel extends \WPML_Elementor_Module_With_Items {
 	protected function get_title( $field ) {
 		switch ( $field ) {
 			case 'url':
-				return esc_html__( 'Media Carousel: link URL', 'sitepress' );
+				return esc_html__( 'Media Carousel: slide URL', 'sitepress' );
 			default:
 				return '';
 		}

--- a/src/modules/MediaCarousel.php
+++ b/src/modules/MediaCarousel.php
@@ -17,7 +17,7 @@ class MediaCarousel extends \WPML_Elementor_Module_With_Items {
 	public function get_fields() {
 		return [ 
 			'image_link_to' => [ 'url' ],
-			'video' => [ 'url ']
+			'video' => [ 'url']
 		];
 	}
 

--- a/tests/phpunit/tests/modules/TestMediaCarousel.php
+++ b/tests/phpunit/tests/modules/TestMediaCarousel.php
@@ -14,6 +14,7 @@ class TestMediaCarousel extends \OTGS_TestCase {
 	public function it_get_fields() {
 		$subject = new MediaCarousel();
 		$this->assertEquals( [ 'image_link_to' => [ 'url' ] ], $subject->get_fields() );
+		$this->assertEquals( [ 'video' => [ 'url' ] ], $subject->get_fields() );
 	}
 
 	/**

--- a/tests/phpunit/tests/modules/TestMediaCarousel.php
+++ b/tests/phpunit/tests/modules/TestMediaCarousel.php
@@ -13,8 +13,7 @@ class TestMediaCarousel extends \OTGS_TestCase {
 	 */
 	public function it_get_fields() {
 		$subject = new MediaCarousel();
-		$this->assertEquals( [ 'image_link_to' => [ 'url' ] ], $subject->get_fields() );
-		$this->assertEquals( [ 'video' => [ 'url' ] ], $subject->get_fields() );
+		$this->assertEquals( [ 'image_link_to' => [ 'url' ], 'video' => [ 'url' ] ], $subject->get_fields() );
 	}
 
 	/**


### PR DESCRIPTION
I tried to provide individual titles for the `image_link_to` and the `video` URL fields but the changes and tests required are probably not worth it since we are moving towards XML config for these widgets.