### PR TITLE
[Elementor] Confusing setting for Language Switcher widget #138

### DIFF
--- a/src/LanguageSwitcher/WidgetAdaptor.php
+++ b/src/LanguageSwitcher/WidgetAdaptor.php
@@ -88,6 +88,16 @@ class WidgetAdaptor {
 				'type'         => Controls_Manager::SWITCHER,
 				'return_value' => 1,
 				'default'      => 1,
+				'conditions' => [
+					'relation' => 'and',
+					'terms'    => [
+						[
+							'name'     => 'style',
+							'operator' => '!=',
+							'value'   => 'custom',
+						]
+					]
+				],
 			]
 		);
 

--- a/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
+++ b/tests/phpunit/tests/LanguageSwitcher/TestWidgetAdaptor.php
@@ -156,6 +156,16 @@ class TestWidgetAdaptor extends \OTGS_TestCase {
 					       'type'         => Controls_Manager::SWITCHER,
 					       'return_value' => 1,
 					       'default'      => 1,
+						   'conditions' => [
+							   'relation' => 'and',
+							   'terms'    => [
+								   [
+									   'name'     => 'style',
+									   'operator' => '!=',
+									   'value'   => 'custom',
+								   ]
+							   ]
+						   ],
 				       ],
 			       ],
 			       [


### PR DESCRIPTION
When selecting the "custom" language switcher, the specific settings are controled from WPML > Langauges > Custom Language Switcher

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7740