### PR TITLE
Filter `wpml_pb_is_editing_translation_with_native_editor`

### DIFF
--- a/src/Hooks/Editor.php
+++ b/src/Hooks/Editor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+use WPML\FP\Obj;
+use WPML\FP\Relation;
+use WPML\LIB\WP\Hooks;
+use function WPML\FP\spreadArgs;
+
+class Editor implements \IWPML_Backend_Action {
+
+	public function add_hooks() {
+		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor' )
+			->then( spreadArgs( function( $isTranslationWithNativeEditor ) {
+				return $isTranslationWithNativeEditor
+				       || (
+				       	    Obj::prop( 'editor_post_id', $_POST )
+				            && Relation::propEq( 'action', 'elementor_ajax', $_POST )
+				       );
+			} ) );
+	}
+}

--- a/src/class-wpml-elementor-integration-factory.php
+++ b/src/class-wpml-elementor-integration-factory.php
@@ -27,6 +27,7 @@ class WPML_Elementor_Integration_Factory {
 				\WPML\PB\Elementor\Hooks\Frontend::class,
 				\WPML\PB\Elementor\Config\Factory::class,
 				\WPML\PB\Elementor\Hooks\LandingPages::class,
+				\WPML\PB\Elementor\Hooks\Editor::class,
 				\WPML_PB_Fix_Maintenance_Query::class,
 			)
 		);

--- a/tests/phpunit/tests/Hooks/TestEditor.php
+++ b/tests/phpunit/tests/Hooks/TestEditor.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace WPML\PB\Elementor\Hooks;
+
+use WPML\LIB\WP\OnActionMock;
+
+/**
+ * @group hooks
+ * @group editor
+ */
+class TestEditor extends \OTGS_TestCase {
+
+	use OnActionMock;
+
+	public function setUp() {
+		parent::setUp();
+		$this->setUpOnAction();
+	}
+
+	public function tearDown() {
+		unset( $_POST['editor_post_id'], $_POST['elementor_ajax'] );
+		$this->tearDownOnAction();
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsTrueIfAlreadyTranslatingWithNativeEditor() {
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsTrueIfTranslatingWithElementorNativeEditor() {
+		$_POST = [
+			'editor_post_id' => 123,
+			'action'         => 'elementor_ajax',
+		];
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpNotTranslatingWithElementorNativeEditor
+	 *
+	 * @param array $postData
+	 */
+	public function itReturnsFalseIfNotTranslatingWithElementorNativeEditor( $postData ) {
+		$_POST = $postData;
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertFalse( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+	}
+
+	public function dpNotTranslatingWithElementorNativeEditor() {
+		return [
+			[
+				[],
+			],
+			[
+				[
+					'action'         => 'elementor_ajax',
+				],
+			],
+			[
+				[
+					'editor_post_id' => 123,
+					'action'         => 'not_the_right_action',
+				],
+			],
+		];
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-elementor-integration-factory.php
@@ -33,6 +33,7 @@ class Test_WPML_Elementor_Integration_Factory extends OTGS_TestCase {
 			                     \WPML\PB\Elementor\Hooks\Frontend::class,
 			                     \WPML\PB\Elementor\Config\Factory::class,
 			                     \WPML\PB\Elementor\Hooks\LandingPages::class,
+			                     \WPML\PB\Elementor\Hooks\Editor::class,
 			                     \WPML_PB_Fix_Maintenance_Query::class,
 		                     ) );
 


### PR DESCRIPTION
Requires https://github.com/OnTheGoSystems/wpml-page-builders/pull/131.

This will ensure we set the right `_last_translation_edit_mode` post
meta when a translation is edited with Elementor's editor.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7656