### PR TITLE
Improve `DataConvert::unserialize` to be tolerant with already unserialized data

### DIFF
--- a/src/DataConvert.php
+++ b/src/DataConvert.php
@@ -2,6 +2,8 @@
 
 namespace WPML\PB\Elementor;
 
+use WPML\FP\Obj;
+
 class DataConvert {
 
 	/**
@@ -19,6 +21,7 @@ class DataConvert {
 	 * @return array
 	 */
 	public static function unserialize( $data ) {
-		return json_decode( is_array( $data ) ? $data[0] : $data, true );
+		$maybeEncoded = is_array( $data ) ? Obj::prop( 0, $data ) : $data;
+		return is_string( $maybeEncoded ) ? json_decode( $maybeEncoded, true ) : $data;
 	}
 }

--- a/src/class-wpml-elementor-adjust-global-widget-id.php
+++ b/src/class-wpml-elementor-adjust-global-widget-id.php
@@ -50,7 +50,8 @@ class WPML_Elementor_Adjust_Global_Widget_ID {
 
 		$custom_field_data = get_post_meta(
 			$post_id,
-			$this->elementor_settings->get_meta_field()
+			$this->elementor_settings->get_meta_field(),
+			true
 		);
 
 		if ( ! $custom_field_data ) {

--- a/tests/phpunit/tests/Hooks/TestGutenbergCleanup.php
+++ b/tests/phpunit/tests/Hooks/TestGutenbergCleanup.php
@@ -6,6 +6,7 @@ use tad\FunctionMocker\FunctionMocker;
 use WPML\FP\Fns;
 use WPML\LIB\WP\PostMock;
 use WPML\LIB\WP\Post;
+use WPML\LIB\WP\WPDBMock;
 use WPML_Elementor_Data_Settings;
 
 /**
@@ -15,11 +16,13 @@ use WPML_Elementor_Data_Settings;
 class TestGutenbergCleanup extends \OTGS_TestCase {
 
 	use PostMock;
+	use WPDBMock;
 
 	public function setUp() {
 		parent::setUp();
 
 		$this->setUpPostMock();
+		$this->setUpWPDBMock();
 
 		\WP_Mock::passthruFunction( 'wp_slash' );
 		\WP_Mock::userFunction( 'wp_json_encode', [

--- a/tests/phpunit/tests/TestDataConvert.php
+++ b/tests/phpunit/tests/TestDataConvert.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WPML\PB\Elementor;
+
+/**
+ * @group elementor
+ */
+class TestDataConvert extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dpUnserialize
+	 *
+	 * @param mixed $data
+	 * @param array $expectedOutput
+	 */
+	public function itUnserializes( $data, $expectedOutput ) {
+		$this->assertEquals( $expectedOutput, DataConvert::unserialize( $data ) );
+	}
+
+	public function dpUnserialize() {
+		return [
+			'json string' => [
+				'{"foo":"bar"}',
+				[ 'foo' => 'bar' ]
+			],
+			'json string in array' => [
+				[ '{"foo":"bar"}' ],
+				[ 'foo' => 'bar' ]
+			],
+			'already unserialized - wpmlcore-8775' => [
+				[ 'foo' => 'bar' ],
+				[ 'foo' => 'bar' ]
+			]
+		];
+	}
+}

--- a/tests/phpunit/tests/test-wpml-elementor-adjust-global-widget-id.php
+++ b/tests/phpunit/tests/test-wpml-elementor-adjust-global-widget-id.php
@@ -132,7 +132,7 @@ class Test_WPML_Elementor_Adjust_Global_Widget_ID extends OTGS_TestCase {
 		$element_factory->shouldReceive( 'create_post' )->with( $global_id )->andReturn( $global_element );
 
 		\WP_Mock::userFunction( 'get_post_meta', array(
-			'args'   => array( $post_id, '_elementor_data' ),
+			'args'   => array( $post_id, '_elementor_data', true ),
 			'return' => 'post meta'
 		) );
 
@@ -208,7 +208,7 @@ class Test_WPML_Elementor_Adjust_Global_Widget_ID extends OTGS_TestCase {
 		$element_factory->shouldReceive( 'create_post' )->with( $global_id )->andReturn( $global_element );
 
 		\WP_Mock::userFunction( 'get_post_meta', array(
-			'args'   => array( $post_id, '_elementor_data' ),
+			'args'   => array( $post_id, '_elementor_data', true ),
 			'return' => array(),
 		) );
 


### PR DESCRIPTION
This happens with imported templates provide by Astra theme.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8775

Added an extra commit to fix a non-related unit test.