### PR TITLE
Improve the way we flag a translation has been edited with Elementor editor

### DIFF
--- a/src/Hooks/Editor.php
+++ b/src/Hooks/Editor.php
@@ -10,11 +10,11 @@ use function WPML\FP\spreadArgs;
 class Editor implements \IWPML_Backend_Action {
 
 	public function add_hooks() {
-		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor' )
-			->then( spreadArgs( function( $isTranslationWithNativeEditor ) {
+		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor', 10, 2 )
+			->then( spreadArgs( function( $isTranslationWithNativeEditor, $translatedPostId ) {
 				return $isTranslationWithNativeEditor
 				       || (
-				       	    Obj::prop( 'editor_post_id', $_POST )
+				       	    (int) Obj::prop( 'editor_post_id', $_POST ) === $translatedPostId
 				            && Relation::propEq( 'action', 'elementor_ajax', $_POST )
 				       );
 			} ) );

--- a/tests/phpunit/tests/Hooks/TestEditor.php
+++ b/tests/phpunit/tests/Hooks/TestEditor.php
@@ -12,13 +12,16 @@ class TestEditor extends \OTGS_TestCase {
 
 	use OnActionMock;
 
+	const ORIGINAL_ID    = 123;
+	const TRANSLATION_ID = 456;
+
 	public function setUp() {
 		parent::setUp();
 		$this->setUpOnAction();
 	}
 
 	public function tearDown() {
-		unset( $_POST['editor_post_id'], $_POST['elementor_ajax'] );
+		unset( $_POST['editor_post_id'], $_POST['action'] );
 		$this->tearDownOnAction();
 		parent::tearDown();
 	}
@@ -30,7 +33,7 @@ class TestEditor extends \OTGS_TestCase {
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true ) );
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true, self::TRANSLATION_ID ) );
 	}
 
 	/**
@@ -38,14 +41,14 @@ class TestEditor extends \OTGS_TestCase {
 	 */
 	public function itReturnsTrueIfTranslatingWithElementorNativeEditor() {
 		$_POST = [
-			'editor_post_id' => 123,
+			'editor_post_id' => (string) self::TRANSLATION_ID,
 			'action'         => 'elementor_ajax',
 		];
 
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATION_ID ) );
 	}
 
 	/**
@@ -60,7 +63,7 @@ class TestEditor extends \OTGS_TestCase {
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertFalse( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+		$this->assertFalse( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATION_ID ) );
 	}
 
 	public function dpNotTranslatingWithElementorNativeEditor() {
@@ -75,8 +78,15 @@ class TestEditor extends \OTGS_TestCase {
 			],
 			[
 				[
-					'editor_post_id' => 123,
+					'editor_post_id' => (string) self::TRANSLATION_ID,
 					'action'         => 'not_the_right_action',
+				],
+			],
+			// wpmlcore-8858 - globally editing the original
+			[
+				[
+					'editor_post_id' => (string) self::ORIGINAL_ID,
+					'action'         => 'elementor_ajax',
 				],
 			],
 		];

--- a/tests/phpunit/tests/Hooks/TestGutenbergCleanup.php
+++ b/tests/phpunit/tests/Hooks/TestGutenbergCleanup.php
@@ -6,6 +6,7 @@ use tad\FunctionMocker\FunctionMocker;
 use WPML\FP\Fns;
 use WPML\LIB\WP\PostMock;
 use WPML\LIB\WP\Post;
+use WPML\LIB\WP\WPDBMock;
 use WPML_Elementor_Data_Settings;
 
 /**
@@ -15,11 +16,13 @@ use WPML_Elementor_Data_Settings;
 class TestGutenbergCleanup extends \OTGS_TestCase {
 
 	use PostMock;
+	use WPDBMock;
 
 	public function setUp() {
 		parent::setUp();
 
 		$this->setUpPostMock();
+		$this->setUpWPDBMock();
 
 		\WP_Mock::passthruFunction( 'wp_slash' );
 		\WP_Mock::userFunction( 'wp_json_encode', [


### PR DESCRIPTION
I added an extra commit to fix unit tests but it's not related (a change in the dependencies mocks).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8858